### PR TITLE
feat: Implement discard edits functionality in Climbing context

### DIFF
--- a/src/components/FeaturePanel/Climbing/ClimbingCragDialog.tsx
+++ b/src/components/FeaturePanel/Climbing/ClimbingCragDialog.tsx
@@ -18,6 +18,7 @@ import { useSaveCragFactory } from './useSaveCragFactory';
 import { getWikimediaCommonsPhotoKeys, removeFilePrefix } from './utils/photo';
 import { ClimbingEditorHelperText } from './ClimbingEditorHelperText';
 import { t } from '../../../services/intl';
+import { confirmDiscardUnsavedClimbingEdits } from './utils/confirmDiscardUnsavedClimbingEdits';
 
 const Flex = styled.div`
   display: flex;
@@ -56,6 +57,8 @@ export const ClimbingCragDialog = ({
     photoPath,
     photoPaths,
     loadPhotoRelatedData,
+    discardEdits,
+    hasUnsavedEdits,
   } = useClimbingContext();
   const { feature } = useFeatureContext();
   const saveCrag = useSaveCragFactory(setIsEditMode);
@@ -116,6 +119,10 @@ export const ClimbingCragDialog = ({
     Router.push(`${getOsmappLink(feature)}${window.location.hash}`);
   };
   const handleCancel = () => {
+    if (!confirmDiscardUnsavedClimbingEdits(hasUnsavedEdits)) {
+      return;
+    }
+    discardEdits();
     // Reset UI/machine state so "cancel" leaves editor in a consistent non-edit mode.
     setIsPlacingProtectionPoints(false);
     if (machine.currentStateName === 'extendRoute') {

--- a/src/components/FeaturePanel/Climbing/contexts/ClimbingContext.tsx
+++ b/src/components/FeaturePanel/Climbing/contexts/ClimbingContext.tsx
@@ -159,6 +159,8 @@ type ClimbingContextType = {
     nextCoords: Position,
     snappedFrom?: PathPoint | null,
   ) => void;
+  discardEdits: () => void;
+  hasUnsavedEdits: boolean;
 };
 
 // @TODO generate?
@@ -233,6 +235,69 @@ export const ClimbingContextProvider = ({ children, feature }: Props) => {
     useState(false);
   const [protectionPointSelectedIndex, setProtectionPointSelectedIndex] =
     useState<number | null>(null);
+
+  const [editSnapshot, setEditSnapshot] = useState<{
+    routes: Array<ClimbingRoute>;
+    protectionPointsByPhoto: Record<string, PathPoints>;
+  } | null>(null);
+
+  const editSnapshotRef = useRef<{
+    routes: Array<ClimbingRoute>;
+    protectionPointsByPhoto: Record<string, PathPoints>;
+  } | null>(null);
+
+  const clone = <T,>(value: T): T => {
+    if (typeof structuredClone === 'function') {
+      return structuredClone(value);
+    }
+    return JSON.parse(JSON.stringify(value)) as T;
+  };
+
+  const stableStringify = (value: unknown): string => {
+    const seen = new WeakSet<object>();
+    const normalize = (v: any): any => {
+      if (v === null || typeof v !== 'object') return v;
+      if (seen.has(v)) return '[Circular]';
+      seen.add(v);
+      if (Array.isArray(v)) return v.map(normalize);
+      const out: Record<string, any> = {};
+      for (const key of Object.keys(v).sort()) {
+        out[key] = normalize(v[key]);
+      }
+      return out;
+    };
+    return JSON.stringify(normalize(value));
+  };
+
+  useEffect(() => {
+    if (!isEditMode) return;
+    const snapshot = {
+      routes: clone(routes),
+      protectionPointsByPhoto: clone(protectionPointsByPhoto),
+    };
+    editSnapshotRef.current = snapshot;
+    setEditSnapshot(snapshot);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isEditMode]);
+
+  const discardEdits = useCallback(() => {
+    const snapshot = editSnapshotRef.current;
+    if (snapshot) {
+      setRoutes(snapshot.routes);
+      setProtectionPointsByPhoto(snapshot.protectionPointsByPhoto);
+      return;
+    }
+    // Fallback (should be rare): reset from original feature tags.
+    setRoutes(osmToClimbingRoutes(feature));
+    setProtectionPointsByPhoto(parseProtectionPointsByPhoto(feature.tags));
+  }, [feature]);
+
+  const hasUnsavedEdits =
+    isEditMode &&
+    editSnapshot !== null &&
+    (stableStringify(editSnapshot.routes) !== stableStringify(routes) ||
+      stableStringify(editSnapshot.protectionPointsByPhoto) !==
+        stableStringify(protectionPointsByPhoto));
 
   const [pointElement, setPointElement] = useState<null | HTMLElement>(null);
   const [routeListTopOffsets, setRouteListTopOffsets] = useState<Array<number>>(
@@ -546,6 +611,8 @@ export const ClimbingContextProvider = ({ children, feature }: Props) => {
     removeProtectionPointAtIndex,
     setProtectionPointTypeAtIndex,
     updateProtectionPointPositionAtIndex,
+    discardEdits,
+    hasUnsavedEdits,
   };
 
   return (

--- a/src/components/FeaturePanel/Climbing/utils/confirmDiscardUnsavedClimbingEdits.ts
+++ b/src/components/FeaturePanel/Climbing/utils/confirmDiscardUnsavedClimbingEdits.ts
@@ -1,0 +1,11 @@
+export function confirmDiscardUnsavedClimbingEdits(
+  hasUnsavedEdits: boolean,
+): boolean {
+  if (!hasUnsavedEdits) {
+    return true;
+  }
+  // eslint-disable-next-line no-alert
+  return window.confirm(
+    'Are you sure you want to cancel? You might loose your changes.',
+  );
+}

--- a/src/components/FeaturePanel/Climbing/utils/useClimbingViewShortcuts.ts
+++ b/src/components/FeaturePanel/Climbing/utils/useClimbingViewShortcuts.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useClimbingContext } from '../contexts/ClimbingContext';
 import { usePhotoChange } from './usePhotoChange';
 import { useUserSettingsContext } from '../../../utils/userSettings/UserSettingsContext';
+import { confirmDiscardUnsavedClimbingEdits } from './confirmDiscardUnsavedClimbingEdits';
 
 export const useClimbingViewShortcuts = () => {
   const {
@@ -11,6 +12,8 @@ export const useClimbingViewShortcuts = () => {
     photoPath,
     photoPaths,
     isEditMode,
+    discardEdits,
+    hasUnsavedEdits,
   } = useClimbingContext();
   const onPhotoChange = usePhotoChange();
   const { userSettings, setUserSetting } = useUserSettingsContext();
@@ -34,6 +37,12 @@ export const useClimbingViewShortcuts = () => {
         }
       }
       if (e.key === 'Escape') {
+        if (isEditMode) {
+          if (!confirmDiscardUnsavedClimbingEdits(hasUnsavedEdits)) {
+            return;
+          }
+          discardEdits();
+        }
         setIsEditMode(false);
       }
       if (e.ctrlKey && e.key === 'd') {
@@ -62,6 +71,8 @@ export const useClimbingViewShortcuts = () => {
     photoPath,
     onPhotoChange,
     isEditMode,
+    discardEdits,
+    hasUnsavedEdits,
     setUserSetting,
     userSettings,
   ]);


### PR DESCRIPTION
<!-- Please, remove any section which is not applicable/useful. -->

### Description

### Example links

### Screenshots

<!-- consider using smaller images, eg. <img src="url" width="500"> instead of ![](url) -->

### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)
