### PR TITLE
fix: Ignore shortcuts while edit dialog is opened

### DIFF
--- a/src/components/FeaturePanel/Climbing/Editor/useFloatingMenuShortcuts.tsx
+++ b/src/components/FeaturePanel/Climbing/Editor/useFloatingMenuShortcuts.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { PointType } from '../types';
 import { useClimbingContext } from '../contexts/ClimbingContext';
+import { isTypingInFormField } from '../../../../helpers/hooks';
 
 export const useFloatingMenuShortcuts = (
   onPointTypeChange: (type: PointType | null) => void,
@@ -15,6 +16,8 @@ export const useFloatingMenuShortcuts = (
 
   useEffect(() => {
     const downHandler = (e) => {
+      if (isTypingInFormField(e.target)) return;
+
       if (isEditMode) {
         if (e.key === 'b') {
           onPointTypeChange('bolt');

--- a/src/components/FeaturePanel/Climbing/RouteList/RouteList.tsx
+++ b/src/components/FeaturePanel/Climbing/RouteList/RouteList.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 
 import { useClimbingContext } from '../contexts/ClimbingContext';
 import { RouteListDndContent } from './RouteListDndContent';
+import { isTypingInFormField } from '../../../../helpers/hooks';
 
 const Container = styled.div`
   padding-bottom: 20px;
@@ -21,6 +22,7 @@ export const RouteList = ({ isEditable }: { isEditable?: boolean }) => {
   useEffect(() => {
     const downHandler = (e) => {
       if (routes.length === 0) return;
+      if (isTypingInFormField(e.target)) return;
 
       if (e.key === 'ArrowDown') {
         const nextRoute = routes[routeSelectedIndex + 1];

--- a/src/components/FeaturePanel/Climbing/utils/useClimbingViewShortcuts.ts
+++ b/src/components/FeaturePanel/Climbing/utils/useClimbingViewShortcuts.ts
@@ -3,6 +3,7 @@ import { useClimbingContext } from '../contexts/ClimbingContext';
 import { usePhotoChange } from './usePhotoChange';
 import { useUserSettingsContext } from '../../../utils/userSettings/UserSettingsContext';
 import { confirmDiscardUnsavedClimbingEdits } from './confirmDiscardUnsavedClimbingEdits';
+import { isTypingInFormField } from '../../../../helpers/hooks';
 
 export const useClimbingViewShortcuts = () => {
   const {
@@ -19,6 +20,8 @@ export const useClimbingViewShortcuts = () => {
   const { userSettings, setUserSetting } = useUserSettingsContext();
   useEffect(() => {
     const downHandler = (e) => {
+      if (isTypingInFormField(e.target)) return;
+
       if (e.ctrlKey && e.key === 'h') {
         setIsRoutesLayerVisible(!isRoutesLayerVisible);
       }

--- a/src/helpers/hooks.ts
+++ b/src/helpers/hooks.ts
@@ -60,13 +60,20 @@ export const useKeyDown = (
   }, [key, listener]);
 };
 
+export const isTypingInFormField = (target: EventTarget | null): boolean => {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target instanceof HTMLInputElement) return true;
+  if (target instanceof HTMLTextAreaElement) return true;
+  if (target instanceof HTMLSelectElement) return true;
+  if (target.isContentEditable) return true;
+  return false;
+};
+
 export const useFocusOnSlash = (
   inputRef: React.MutableRefObject<HTMLInputElement>,
 ) => {
   useKeyDown('/', (e) => {
-    const isEventInInput = e.target instanceof HTMLInputElement;
-    const isEventInTextarea = e.target instanceof HTMLTextAreaElement;
-    if (!isEventInInput && !isEventInTextarea) {
+    if (!isTypingInFormField(e.target)) {
       e.preventDefault();
       inputRef.current?.focus();
     }

--- a/src/services/osm/auth/osmApiAuth.ts
+++ b/src/services/osm/auth/osmApiAuth.ts
@@ -1,20 +1,20 @@
 // TODO move this file to ./auth folder
 import escape from 'lodash/escape';
-import { Feature, FeatureTags, LonLat, OsmId, SuccessInfo } from '../../types';
-import { getApiId, getFullOsmappLink, getUrlOsmId } from '../../helpers';
-import { join } from '../../../utils';
-import { clearFetchCache } from '../../fetchCache';
-import { getLabel } from '../../../helpers/featureLabel';
-import { OSM_WEBSITE } from '../consts';
-import { getDiffXml } from './getDIffXml';
-import { SingleDocXmljs } from './xmlTypes';
-import { xmljsBuildOsm } from './xmlHelpers';
-import * as api from './api';
-import { getFirstExistingId } from '../getFirstExistingId';
 import {
   DataItem,
   Members,
 } from '../../../components/FeaturePanel/EditDialog/context/types';
+import { getLabel } from '../../../helpers/featureLabel';
+import { join } from '../../../utils';
+import { clearFetchCache } from '../../fetchCache';
+import { getApiId, getFullOsmappLink, getUrlOsmId } from '../../helpers';
+import { Feature, FeatureTags, LonLat, OsmId, SuccessInfo } from '../../types';
+import { OSM_WEBSITE } from '../consts';
+import { getFirstExistingId } from '../getFirstExistingId';
+import * as api from './api';
+import { getDiffXml } from './getDIffXml';
+import { xmljsBuildOsm } from './xmlHelpers';
+import { SingleDocXmljs } from './xmlTypes';
 
 export const getChangesetXml = ({ changesetComment, feature }) => {
   const tags = [
@@ -39,7 +39,7 @@ const getChangesetComment = (
   const action = undelete ? 'Undeleted' : toBeDeleted ? 'Deleted' : 'Edited';
   const name = getLabel(original) || getUrlOsmId(original.osmMeta);
   const description = `${action} ${name}`;
-  return join(comment, ' • ', `${description} #osmapp`);
+  return join(comment, ' • ', `${description} #openclimbing.org`);
 };
 
 const getXmlTags = (newTags: FeatureTags) =>
@@ -87,14 +87,14 @@ const getCommentMulti = (
   const suffix = changes.some(isClimbingChange) ? ' #climbing' : '';
 
   // TODO find topmost parent in changes and use its name
-  // eg. survey • Edited Roviště (5 items) #osmapp #climbing
+  // eg. survey • Edited Roviště (5 items) #openclimbing.org #climbing
 
   if (original.point) {
     // adding a new node or relation
     const typeTag = changes[0].tagsEntries[0]?.join('=') ?? 'item with no tags';
     const name = Object.fromEntries(changes[0].tagsEntries).name ?? '';
     const label = join(typeTag, ' ', name);
-    return join(comment, ' • ', `Added ${label} #osmapp${suffix}`);
+    return join(comment, ' • ', `Added ${label} #openclimbing.org`);
   }
 
   const toBeDeleted = changes.length === 1 && changes[0].toBeDeleted;


### PR DESCRIPTION
<!-- Please, remove any section which is not applicable/useful. -->

### Description

### Example links

### Screenshots

<!-- consider using smaller images, eg. <img src="url" width="500"> instead of ![](url) -->

### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)
