### PR TITLE
Add country flags, filter and sorting to climbing areas page

### DIFF
--- a/pages/climbing-areas.tsx
+++ b/pages/climbing-areas.tsx
@@ -4,6 +4,7 @@ import {
   ClimbingArea,
   getClimbingAreas,
 } from '../src/services/climbing-areas/getClimbingAreas';
+import { resolveCountryCode } from 'next-codegrid';
 
 type Props = {
   climbingAreas: Array<ClimbingArea>;
@@ -15,6 +16,22 @@ const ClimbingAreasPage: NextPage<Props> = ({ climbingAreas }) => {
 
 ClimbingAreasPage.getInitialProps = async () => {
   const climbingAreas = await getClimbingAreas();
+
+  await Promise.all(
+    climbingAreas.map(async (area) => {
+      if (area.center) {
+        try {
+          const code = await resolveCountryCode([
+            area.center.lon,
+            area.center.lat,
+          ]);
+          area.countryCode = code ?? undefined;
+        } catch {
+          // leave countryCode undefined
+        }
+      }
+    }),
+  );
 
   return {
     climbingAreas,

--- a/src/components/ClimbingAreasPanel/ClimbingAreasPanel.tsx
+++ b/src/components/ClimbingAreasPanel/ClimbingAreasPanel.tsx
@@ -1,13 +1,18 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import Router from 'next/router';
 import {
+  FormControl,
+  InputLabel,
+  MenuItem,
   Paper,
+  Select,
   Table,
   TableBody,
   TableCell,
   TableContainer,
   TableHead,
   TableRow,
+  TableSortLabel,
 } from '@mui/material';
 import { intl, t } from '../../services/intl';
 import { ClosePanelButton } from '../utils/ClosePanelButton';
@@ -25,10 +30,80 @@ type ClimbingAreasPanelProps = {
   areas: ClimbingArea[];
 };
 
+type SortBy = 'name' | 'country' | 'crags';
+type SortDir = 'asc' | 'desc';
+
+const countryCodeToFlag = (code: string): string =>
+  code
+    .toUpperCase()
+    .split('')
+    .map((c) => String.fromCodePoint(0x1f1e6 + c.charCodeAt(0) - 65))
+    .join('');
+
+const getCountryName = (countryCode: string): string => {
+  try {
+    return (
+      new Intl.DisplayNames(['en'], { type: 'region' }).of(
+        countryCode.toUpperCase(),
+      ) ?? countryCode.toUpperCase()
+    );
+  } catch {
+    return countryCode.toUpperCase();
+  }
+};
+
 export const ClimbingAreasPanel = ({ areas }: ClimbingAreasPanelProps) => {
   const handleClose = () => {
     Router.push(`/`);
   };
+
+  const [filterCountry, setFilterCountry] = useState<string>('');
+  const [sortBy, setSortBy] = useState<SortBy>('name');
+  const [sortDir, setSortDir] = useState<SortDir>('asc');
+
+  const countries = useMemo(() => {
+    const codes = [
+      ...new Set(areas.map((a) => a.countryCode).filter(Boolean)),
+    ] as string[];
+    return codes
+      .map((code) => ({
+        code,
+        name: getCountryName(code),
+        flag: countryCodeToFlag(code),
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [areas]);
+
+  const handleSort = (column: SortBy) => {
+    if (sortBy === column) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortBy(column);
+      setSortDir('asc');
+    }
+  };
+
+  const processedAreas = useMemo(() => {
+    let result = [...areas];
+
+    if (filterCountry) {
+      result = result.filter((a) => a.countryCode === filterCountry);
+    }
+
+    result.sort((a, b) => {
+      let cmp = 0;
+      if (sortBy === 'name') {
+        cmp = (a.tags.name || '').localeCompare(b.tags.name || '');
+      } else if (sortBy === 'country') {
+        cmp = (a.countryCode || '').localeCompare(b.countryCode || '');
+      } else if (sortBy === 'crags') {
+        cmp = (a.members?.length || 0) - (b.members?.length || 0);
+      }
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+
+    return result;
+  }, [areas, filterCountry, sortBy, sortDir]);
 
   return (
     <MobilePageDrawer className="climbing-areas-drawer">
@@ -38,19 +113,59 @@ export const ClimbingAreasPanel = ({ areas }: ClimbingAreasPanelProps) => {
           <PanelSidePadding>
             <ClosePanelButton right onClick={handleClose} />
             <h1>{t('climbingareas.title')}</h1>
+            <FormControl size="small" sx={{ minWidth: 200, mb: 2 }}>
+              <InputLabel>{t('climbingareas.filter_country')}</InputLabel>
+              <Select
+                value={filterCountry}
+                label={t('climbingareas.filter_country')}
+                onChange={(e) => setFilterCountry(e.target.value)}
+              >
+                <MenuItem value="">{t('climbingareas.all_countries')}</MenuItem>
+                {countries.map(({ code, name, flag }) => (
+                  <MenuItem key={code} value={code}>
+                    {flag} {name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
           </PanelSidePadding>
 
           <TableContainer component={Paper}>
             <Table size="small">
               <TableHead>
                 <TableRow>
-                  <TableCell></TableCell>
-                  <TableCell>{t('climbingareas.area')}</TableCell>
-                  <TableCell>{t('climbingareas.num_of_crags')}</TableCell>
+                  <TableCell>#</TableCell>
+                  <TableCell>
+                    <TableSortLabel
+                      active={sortBy === 'name'}
+                      direction={sortBy === 'name' ? sortDir : 'asc'}
+                      onClick={() => handleSort('name')}
+                    >
+                      {t('climbingareas.area')}
+                    </TableSortLabel>
+                  </TableCell>
+                  <TableCell>
+                    <TableSortLabel
+                      active={sortBy === 'country'}
+                      direction={sortBy === 'country' ? sortDir : 'asc'}
+                      onClick={() => handleSort('country')}
+                    >
+                      {t('climbingareas.country')}
+                    </TableSortLabel>
+                  </TableCell>
+                  <TableCell align="right">
+                    <TableSortLabel
+                      active={sortBy === 'crags'}
+                      direction={sortBy === 'crags' ? sortDir : 'asc'}
+                      onClick={() => handleSort('crags')}
+                    >
+                      {t('climbingareas.num_of_crags')}
+                    </TableSortLabel>
+                  </TableCell>
                 </TableRow>
               </TableHead>
               <TableBody>
-                {areas.map((climbingArea, index) => (
+                {processedAreas.map((climbingArea, index) => (
                   <TableRow key={`climbing-area-${climbingArea.id}`}>
                     <TableCell>{index + 1}.</TableCell>
                     <TableCell>
@@ -62,7 +177,16 @@ export const ClimbingAreasPanel = ({ areas }: ClimbingAreasPanelProps) => {
                           `N/A – relation/${climbingArea.id}`}
                       </Link>
                     </TableCell>
-                    <TableCell>{climbingArea.members?.length}</TableCell>
+                    <TableCell>
+                      {climbingArea.countryCode && (
+                        <span title={getCountryName(climbingArea.countryCode)}>
+                          {countryCodeToFlag(climbingArea.countryCode)}
+                        </span>
+                      )}
+                    </TableCell>
+                    <TableCell align="right">
+                      {climbingArea.members?.length}
+                    </TableCell>
                   </TableRow>
                 ))}
               </TableBody>

--- a/src/locales/cs.js
+++ b/src/locales/cs.js
@@ -481,7 +481,10 @@ export default {
   'climbingareas.link': 'Seznam všech lezeckých oblastí',
   'climbingareas.title': 'Lezecké oblasti',
   'climbingareas.area': 'Oblast',
+  'climbingareas.country': 'Země',
   'climbingareas.num_of_crags': 'Počet skal',
+  'climbingareas.filter_country': 'Filtrovat podle země',
+  'climbingareas.all_countries': 'Všechny země',
 
   'hamburger_menu.climbing.title': 'Lezení',
   'climbing_grade_table.title': 'Tabulka lezeckých obtížností',

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -533,7 +533,10 @@ export default {
   'climbingareas.link': 'List of all Climbing areas',
   'climbingareas.title': 'Climbing areas',
   'climbingareas.area': 'Area',
+  'climbingareas.country': 'Country',
   'climbingareas.num_of_crags': 'Number of crags',
+  'climbingareas.filter_country': 'Filter by country',
+  'climbingareas.all_countries': 'All countries',
 
   'hamburger_menu.climbing.title': 'Climbing',
   'climbing_grade_table.title': 'Climbing grades table',

--- a/src/services/climbing-areas/getClimbingAreas.ts
+++ b/src/services/climbing-areas/getClimbingAreas.ts
@@ -1,14 +1,6 @@
 import { fetchOverpass } from '../overpass/fetchOverpass';
 
-/*
-This query doesn't work, because area is usualy a relation of realtions,
-which doesn't hold a center point in overpass:
-
-  [out:json][timeout:300];
-  ( area["ISO3166-1"="CZ"][admin_level=2]; )->.a;
-  rel["climbing"="area"](area.a);
-  out body;
-*/
+type Member = { type: 'node' | 'way' | 'relation'; ref: number; role?: string };
 
 export type ClimbingArea = {
   id: number;
@@ -16,12 +8,108 @@ export type ClimbingArea = {
   tags: {
     name: string;
   };
-  members: any[];
+  members: Member[];
+  center?: {
+    lat: number;
+    lon: number;
+  };
+  countryCode?: string;
+};
+
+type OsmEl = {
+  type: 'node' | 'way' | 'relation';
+  id: number;
+  lat?: number;
+  lon?: number;
+  center?: { lat: number; lon: number };
+  members?: Member[];
+};
+
+const CHUNK_SIZE = 100; // keeps the request URL well under any server limit
+
+const walkForCenter = (
+  el: OsmEl,
+  byKey: Map<string, OsmEl>,
+  visited: Set<string>,
+): { lat: number; lon: number } | null => {
+  const key = `${el.type}/${el.id}`;
+  if (visited.has(key)) return null;
+  visited.add(key);
+
+  if (el.type === 'node' && el.lat != null && el.lon != null) {
+    return { lat: el.lat, lon: el.lon };
+  }
+  if (el.center) return el.center;
+
+  for (const m of el.members ?? []) {
+    const child = byKey.get(`${m.type}/${m.ref}`);
+    if (!child) continue;
+    const c = walkForCenter(child, byKey, visited);
+    if (c) return c;
+  }
+  return null;
+};
+
+const fetchCentersForChunk = async (
+  ids: number[],
+): Promise<Map<number, { lat: number; lon: number }>> => {
+  const result = new Map<number, { lat: number; lon: number }>();
+
+  // Recurse all descendants into the result set, then walk each relation's
+  // member tree in JS to find a representative coordinate. Overpass's plain
+  // `out center` doesn't compute a centre for relations whose members are only
+  // sub-relations – see https://github.com/drolbr/Overpass-API/issues/733
+  const query = `[out:json][timeout:300];rel(id:${ids.join(',')})->.a;(.a;.a >>;);out body center qt;`;
+
+  try {
+    const response = await fetchOverpass(query);
+    const elements = (response?.elements ?? []) as OsmEl[];
+
+    const byKey = new Map<string, OsmEl>();
+    for (const el of elements) {
+      byKey.set(`${el.type}/${el.id}`, el);
+    }
+
+    for (const id of ids) {
+      const root = byKey.get(`relation/${id}`);
+      if (!root) continue;
+      const center = walkForCenter(root, byKey, new Set());
+      if (center) result.set(id, center);
+    }
+  } catch (e) {
+    console.warn('fetchCentersForChunk() failed:', e); // eslint-disable-line no-console
+  }
+
+  return result;
+};
+
+const fetchMissingCenters = async (
+  ids: number[],
+): Promise<Map<number, { lat: number; lon: number }>> => {
+  const result = new Map<number, { lat: number; lon: number }>();
+  for (let i = 0; i < ids.length; i += CHUNK_SIZE) {
+    const part = await fetchCentersForChunk(ids.slice(i, i + CHUNK_SIZE));
+    for (const [id, c] of part) result.set(id, c);
+  }
+  return result;
 };
 
 export const getClimbingAreas = async (): Promise<ClimbingArea[]> => {
-  const query = `[out:json][timeout:300]; rel["climbing"="area"]; out body;`;
+  const query = `[out:json][timeout:300]; rel["climbing"="area"]; out body center;`;
 
-  const areas = await fetchOverpass(query);
-  return areas?.elements as ClimbingArea[];
+  const areas = (await fetchOverpass(query))?.elements as ClimbingArea[];
+  if (!areas?.length) return areas;
+
+  const missingIds = areas.filter((a) => !a.center).map((a) => a.id);
+  if (missingIds.length > 0) {
+    const centers = await fetchMissingCenters(missingIds);
+    for (const area of areas) {
+      if (!area.center) {
+        const center = centers.get(area.id);
+        if (center) area.center = center;
+      }
+    }
+  }
+
+  return areas;
 };


### PR DESCRIPTION
- Fetch center coordinates from Overpass (out body center) to enable country lookup
- Resolve country codes server-side via resolveCountryCode during getInitialProps
- Display country flag emoji next to each area in the table
- Add dropdown filter to show only areas from a selected country
- Make Name, Country and Number of crags columns sortable (asc/desc)
- Add translation keys for new UI (EN + CS)

https://claude.ai/code/session_012tJG3dzEw8JB5MRdfuKoW2