### PR TITLE
fix: Split panel

### DIFF
--- a/src/components/FeaturePanel/Climbing/ClimbingCragDialogHeader.tsx
+++ b/src/components/FeaturePanel/Climbing/ClimbingCragDialogHeader.tsx
@@ -1,8 +1,7 @@
-import React, { useState } from 'react';
 import styled from '@emotion/styled';
 import CloseIcon from '@mui/icons-material/Close';
-import TuneIcon from '@mui/icons-material/Tune';
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
+import TuneIcon from '@mui/icons-material/Tune';
 import {
   AppBar,
   Box,
@@ -11,16 +10,17 @@ import {
   Tooltip,
   Typography,
 } from '@mui/material';
+import { useState } from 'react';
+import { getLabel } from '../../../helpers/featureLabel';
+import { t } from '../../../services/intl';
+import { UserSettingsDialog } from '../../HomepagePanel/UserSettingsDialog';
+import { useFeatureContext } from '../../utils/FeatureContext';
+import { useDragItems } from '../../utils/useDragItems';
+import { ClimbingPdfExportDialog } from './ClimbingPdfExportDialog';
 import { useClimbingContext } from './contexts/ClimbingContext';
 import { PhotoLink } from './PhotoLink';
-import { useFeatureContext } from '../../utils/FeatureContext';
-import { getLabel } from '../../../helpers/featureLabel';
-import { UserSettingsDialog } from '../../HomepagePanel/UserSettingsDialog';
-import { useDragItems } from '../../utils/useDragItems';
 import { moveElementToIndex, toInsertIndexAfterRemove } from './utils/array';
-import { t } from '../../../services/intl';
 import { usePhotoChange } from './utils/usePhotoChange';
-import { ClimbingPdfExportDialog } from './ClimbingPdfExportDialog';
 
 const Title = styled.div`
   flex: 1;
@@ -140,7 +140,7 @@ export const ClimbingCragDialogHeader = ({ onClose }) => {
                           }
                         : {})}
                     >
-                      {index}
+                      {index + 1}
                     </PhotoLink>
                     <HighlightedDropzone index={index} />
                   </ItemContainer>

--- a/src/components/FeaturePanel/Climbing/ClimbingView.tsx
+++ b/src/components/FeaturePanel/Climbing/ClimbingView.tsx
@@ -39,6 +39,9 @@ const BottomContainer = styled.div`
   display: flex;
   flex-direction: column;
   height: 100%;
+  // Establish a container so descendants can adapt to the right panel's width
+  // via @container queries (header, edit button, grade alignment, ...).
+  container-type: inline-size;
 `;
 const FabContainer = styled.div`
   position: absolute;
@@ -438,15 +441,27 @@ export const ClimbingView = () => {
       {photoPath ? (
         <SplitPane
           split={cragViewLayout}
-          minSize={0}
-          maxSize="100%"
+          // Keep the photo pane at least 150 px so the right/bottom panel can
+          // never grow to the point of hiding the photo entirely.
+          minSize={150}
+          // Negative maxSize = stop divider N px before container's far edge.
+          // A string like "100%" is silently ignored (only numbers are honored),
+          // so the divider would otherwise drift past any CSS cap.
+          maxSize={-100}
           size={splitPaneSize ?? SPLIT_PANE_DEFAULT_SIZE}
           onDragStarted={onDragStarted}
           onDragFinished={onDragFinished}
           pane1Style={
             cragViewLayout === 'vertical'
-              ? { maxWidth: 'calc(100vw - 300px)' }
-              : { maxHeight: '90%' }
+              ? { maxWidth: 'calc(100vw - 100px)' }
+              : { maxHeight: 'calc(100% - 100px)' }
+          }
+          // Without this, pane2's default flex `min-width: auto` is its
+          // content's intrinsic width (~417px in this list). Pane2 then refuses
+          // to shrink below that, while react-split-pane still inflates pane1's
+          // inline width past the visible area, shifting the cover background.
+          pane2Style={
+            cragViewLayout === 'vertical' ? { minWidth: 0 } : { minHeight: 0 }
           }
         >
           <BackgroundContainer

--- a/src/components/FeaturePanel/Climbing/ClimbingViewContent.tsx
+++ b/src/components/FeaturePanel/Climbing/ClimbingViewContent.tsx
@@ -1,25 +1,24 @@
 import styled from '@emotion/styled';
+import { Button, ButtonGroup, Typography } from '@mui/material';
 import {
   CLIMBING_ROUTE_ROW_HEIGHT,
   DIALOG_TOP_BAR_HEIGHT,
   SPLIT_PANE_DEFAULT_SIZE,
 } from './config';
-import { useClimbingContext } from './contexts/ClimbingContext';
-import { invertedBoltCodeMap } from './utils/boltCodes';
-import { RouteList } from './RouteList/RouteList';
 import { ContentContainer } from './ContentContainer';
-import { Button, ButtonGroup, Typography } from '@mui/material';
+import { useClimbingContext } from './contexts/ClimbingContext';
+import { RouteList } from './RouteList/RouteList';
+import { invertedBoltCodeMap } from './utils/boltCodes';
 
-import { RouteDistribution } from './RouteDistribution';
-import React from 'react';
 import dynamic from 'next/dynamic';
+import { t } from '../../../services/intl';
+import { useFeatureContext } from '../../utils/FeatureContext';
+import { useUserSettingsContext } from '../../utils/userSettings/UserSettingsContext';
 import { EditButton } from '../EditButton';
 import { EditDialog } from '../EditDialog/EditDialog';
-import { useGetCragViewLayout } from './utils/useCragViewLayout';
-import { useUserSettingsContext } from '../../utils/userSettings/UserSettingsContext';
-import { useFeatureContext } from '../../utils/FeatureContext';
 import { PanelLabel } from './PanelLabel';
-import { t } from '../../../services/intl';
+import { RouteDistribution } from './RouteDistribution';
+import { useGetCragViewLayout } from './utils/useCragViewLayout';
 
 const CragMapDynamic = dynamic(() => import('./CragMap'), {
   ssr: false,
@@ -39,6 +38,12 @@ const ContentBelowRouteList = styled.div<{
       ${DIALOG_TOP_BAR_HEIGHT + CLIMBING_ROUTE_ROW_HEIGHT + 40}px
   );`
       : `calc(100vh - ${DIALOG_TOP_BAR_HEIGHT + CLIMBING_ROUTE_ROW_HEIGHT + 40}px);`};
+`;
+
+const HideOnNarrowPanel = styled.div`
+  @container (max-width: 220px) {
+    display: none;
+  }
 `;
 
 export const ClimbingViewContent = ({ isMapVisible }) => {
@@ -93,16 +98,18 @@ export const ClimbingViewContent = ({ isMapVisible }) => {
             </>
           )}
         </ContentContainer>
-        <RouteDistribution features={feature.memberFeatures} />
+        <HideOnNarrowPanel>
+          <RouteDistribution features={feature.memberFeatures} />
+        </HideOnNarrowPanel>
 
         {feature.tags.description ? (
-          <>
+          <HideOnNarrowPanel>
             <PanelLabel>{t('climbingview.description')}</PanelLabel>
 
-            <Typography ml={4.5} mr={4.5}>
+            <Typography ml={2} mr={2}>
               {feature.tags.description}
             </Typography>
-          </>
+          </HideOnNarrowPanel>
         ) : null}
 
         <EditButton />

--- a/src/components/FeaturePanel/Climbing/RouteList/ClimbingRouteTableRow.tsx
+++ b/src/components/FeaturePanel/Climbing/RouteList/ClimbingRouteTableRow.tsx
@@ -38,6 +38,15 @@ import { PROJECT_ID } from '../../../../services/project';
 
 const Container = styled.div`
   width: 100%;
+  container-type: inline-size;
+`;
+
+const NameColumn = styled(Stack)`
+  // Hide name/description/author when the row becomes too narrow so the panel
+  // can shrink down to ~100px without horizontal overflow.
+  @container (max-width: 220px) {
+    display: none;
+  }
 `;
 const RouteNumberContainer = styled.div`
   width: 22px;
@@ -71,7 +80,19 @@ const RouteDescriptionContainer = styled.div`
 
 const RouteAuthorContainer = styled(RouteDescriptionContainer)``;
 
-const RouteGradeContainer = styled.div``;
+const RouteGradeContainer = styled.div`
+  // When the name column is hidden the grade sits next to the route number
+  // instead of drifting to the row's centre (via flex space-between).
+  @container (max-width: 220px) {
+    margin-right: auto;
+  }
+`;
+
+const MoreMenuContainer = styled.div`
+  @container (max-width: 220px) {
+    display: none;
+  }
+`;
 
 const Row = styled('a', {
   shouldForwardProp: (prop) => !prop.startsWith('$'),
@@ -317,13 +338,15 @@ export const ClimbingRouteTableRow = forwardRef<HTMLDivElement, Props>(
                 {index + 1}
               </RouteNumber>
             </RouteNumberContainer>
-            <Stack justifyContent="stretch" flex={1}>
+            <NameColumn justifyContent="stretch" flex={1}>
               <RouteName feature={feature} selected={isSelected} />
               <RouteDescription feature={feature} />
               <RouteAuthor feature={feature} />
-            </Stack>
+            </NameColumn>
             <RouteGrade feature={feature} />
-            <MoreMenu feature={feature} />
+            <MoreMenuContainer>
+              <MoreMenu feature={feature} />
+            </MoreMenuContainer>
           </Row>
         </Container>
       </>

--- a/src/components/FeaturePanel/Climbing/RouteList/RouteListDndContent.tsx
+++ b/src/components/FeaturePanel/Climbing/RouteList/RouteListDndContent.tsx
@@ -67,6 +67,10 @@ const TableHeader = styled.div`
   font-size: 11px;
   padding-top: 12px;
   padding-bottom: 4px;
+
+  @container (max-width: 220px) {
+    display: none;
+  }
 `;
 const NameHeader = styled.div`
   flex: 1;

--- a/src/components/FeaturePanel/EditButton.tsx
+++ b/src/components/FeaturePanel/EditButton.tsx
@@ -1,4 +1,5 @@
 import { Box, Button } from '@mui/material';
+import styled from '@emotion/styled';
 import EditIcon from '@mui/icons-material/Edit';
 import AddLocationIcon from '@mui/icons-material/AddLocation';
 import React from 'react';
@@ -7,6 +8,24 @@ import { useOsmAuthContext } from '../utils/OsmAuthContext';
 import { useEditDialogContext } from './helpers/EditDialogContext';
 import { useEditDialogFeature } from './EditDialog/utils';
 import CommentIcon from '@mui/icons-material/Comment';
+
+// When this button lives inside a narrow @container (e.g. shrunk climbing
+// side panel), collapse it to an icon-only button.
+const ResponsiveButton = styled(Button)`
+  @container (max-width: 220px) {
+    min-width: 0;
+    padding: 8px;
+    & .MuiButton-startIcon {
+      margin: 0;
+    }
+  }
+`;
+
+const ButtonText = styled.span`
+  @container (max-width: 220px) {
+    display: none;
+  }
+`;
 
 const getLabel = (
   loggedIn: boolean,
@@ -26,7 +45,7 @@ export const EditButton = () => {
 
   return (
     <Box mt={3} mb={3} mx="auto" sx={{ textAlign: 'center' }}>
-      <Button
+      <ResponsiveButton
         size="large"
         startIcon={
           isAddPlace || isUndelete ? (
@@ -41,8 +60,8 @@ export const EditButton = () => {
         color="primary"
         onClick={open}
       >
-        {getLabel(loggedIn, isAddPlace, isUndelete)}
-      </Button>
+        <ButtonText>{getLabel(loggedIn, isAddPlace, isUndelete)}</ButtonText>
+      </ResponsiveButton>
     </Box>
   );
 };


### PR DESCRIPTION
<!-- Please, remove any section which is not applicable/useful. -->

### Description

### Example links

### Screenshots

<!-- consider using smaller images, eg. <img src="url" width="500"> instead of ![](url) -->

### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)
