### PR TITLE
layers: add faded Outdoor layer

### DIFF
--- a/src/components/LayerSwitcher/osmappLayers.tsx
+++ b/src/components/LayerSwitcher/osmappLayers.tsx
@@ -84,6 +84,12 @@ export const osmappLayers: Layers = {
     attribution: ['maptiler', 'osm'],
     // https://api.maptiler.com/tiles/outdoor/tiles.json?key=xxx .planettime="1703030400000",
   },
+  outdoorFaded: {
+    name: t('layers.outdoor_faded'),
+    type: 'basemap',
+    Icon: FilterHdrIcon,
+    attribution: ['maptiler', 'osm'],
+  },
   s1: { type: 'spacer' },
   carto: {
     name: t('layers.carto'),

--- a/src/components/Map/behaviour/featureHover.ts
+++ b/src/components/Map/behaviour/featureHover.ts
@@ -27,6 +27,36 @@ const CLIMBING_CLICKABLE_LAYERS = climbingLayers
   .filter((l) => (l.metadata as any)?.clickableWithOsmId)
   .map((l) => l.id);
 
+// Lightweight hover used purely to highlight features via `feature-state`
+// (e.g. fading out routes that light up on hover). Unlike `setUpHover`, it does
+// not change the cursor, so the features don't look clickable.
+export const setUpHoverHighlight = (map: Map, layerIds: string[]) => {
+  let lastHover: FeatureIdentifier | null = null;
+
+  const off = () => {
+    if (lastHover) {
+      map.setFeatureState(lastHover, { hover: false });
+    }
+    lastHover = null;
+  };
+
+  const onMouseMove = (
+    e: MapMouseEvent & { features?: MapGeoJSONFeature[] },
+  ) => {
+    off();
+    const feature = e.features?.[0];
+    if (feature) {
+      map.setFeatureState(feature, { hover: true });
+      lastHover = feature;
+    }
+  };
+
+  layerIds.forEach((layer) => {
+    map.on('mousemove', layer, onMouseMove);
+    map.on('mouseleave', layer, off);
+  });
+};
+
 export const setUpHover = (map: Map, layersWithOsmId: string[]) => {
   let lastHover = null;
 

--- a/src/components/Map/behaviour/featureHover.ts
+++ b/src/components/Map/behaviour/featureHover.ts
@@ -27,36 +27,6 @@ const CLIMBING_CLICKABLE_LAYERS = climbingLayers
   .filter((l) => (l.metadata as any)?.clickableWithOsmId)
   .map((l) => l.id);
 
-// Lightweight hover used purely to highlight features via `feature-state`
-// (e.g. fading out routes that light up on hover). Unlike `setUpHover`, it does
-// not change the cursor, so the features don't look clickable.
-export const setUpHoverHighlight = (map: Map, layerIds: string[]) => {
-  let lastHover: FeatureIdentifier | null = null;
-
-  const off = () => {
-    if (lastHover) {
-      map.setFeatureState(lastHover, { hover: false });
-    }
-    lastHover = null;
-  };
-
-  const onMouseMove = (
-    e: MapMouseEvent & { features?: MapGeoJSONFeature[] },
-  ) => {
-    off();
-    const feature = e.features?.[0];
-    if (feature) {
-      map.setFeatureState(feature, { hover: true });
-      lastHover = feature;
-    }
-  };
-
-  layerIds.forEach((layer) => {
-    map.on('mousemove', layer, onMouseMove);
-    map.on('mouseleave', layer, off);
-  });
-};
-
 export const setUpHover = (map: Map, layersWithOsmId: string[]) => {
   let lastHover = null;
 

--- a/src/components/Map/behaviour/useUpdateStyle.tsx
+++ b/src/components/Map/behaviour/useUpdateStyle.tsx
@@ -6,7 +6,10 @@ import type { StyleSpecification } from '@maplibre/maplibre-gl-style-spec';
 import { createMapEffectHook } from '../../helpers';
 import { basicStyle } from '../styles/basicStyle';
 import { outdoorStyle } from '../styles/outdoorStyle';
-import { outdoorFadedStyle } from '../styles/outdoorFadedStyle';
+import {
+  outdoorFadedStyle,
+  OUTDOOR_FADED_ROUTE_LAYERS,
+} from '../styles/outdoorFadedStyle';
 import { osmappLayers } from '../../LayerSwitcher/osmappLayers';
 import { getRasterStyle } from '../styles/rasterStyle';
 import { DEFAULT_MAP } from '../../../config.mjs';
@@ -19,7 +22,7 @@ import { EMPTY_GEOJSON_SOURCE, OSMAPP_SPRITE } from '../consts';
 import { fetchCrags } from '../../../services/fetchCrags';
 import { intl } from '../../../services/intl';
 import { Layer } from '../../utils/MapStateContext';
-import { setUpHover } from './featureHover';
+import { setUpHover, setUpHoverHighlight } from './featureHover';
 import { isUrlForRasterLayer, layersWithOsmId } from '../helpers';
 import { Theme } from '../../../helpers/theme';
 import { addIndoorEqual, removeIndoorEqual } from './indoor';
@@ -185,6 +188,10 @@ export const useUpdateStyle = createMapEffectHook(
     map.addControl(languageControl);
 
     setUpHover(map, layersWithOsmId(style));
+
+    if (key === 'outdoorFaded') {
+      setUpHoverHighlight(map, OUTDOOR_FADED_ROUTE_LAYERS);
+    }
 
     if (mapLoaded && overlays.includes('indoor')) {
       addIndoorEqual();

--- a/src/components/Map/behaviour/useUpdateStyle.tsx
+++ b/src/components/Map/behaviour/useUpdateStyle.tsx
@@ -6,6 +6,7 @@ import type { StyleSpecification } from '@maplibre/maplibre-gl-style-spec';
 import { createMapEffectHook } from '../../helpers';
 import { basicStyle } from '../styles/basicStyle';
 import { outdoorStyle } from '../styles/outdoorStyle';
+import { outdoorFadedStyle } from '../styles/outdoorFadedStyle';
 import { osmappLayers } from '../../LayerSwitcher/osmappLayers';
 import { getRasterStyle } from '../styles/rasterStyle';
 import { DEFAULT_MAP } from '../../../config.mjs';
@@ -52,6 +53,9 @@ const getBaseStyle = (key: string, currentTheme: Theme): StyleSpecification => {
   }
   if (key === 'outdoor') {
     return outdoorStyle;
+  }
+  if (key === 'outdoorFaded') {
+    return outdoorFadedStyle;
   }
   if (key === 'shortbread') {
     return currentTheme === 'dark'

--- a/src/components/Map/behaviour/useUpdateStyle.tsx
+++ b/src/components/Map/behaviour/useUpdateStyle.tsx
@@ -6,10 +6,7 @@ import type { StyleSpecification } from '@maplibre/maplibre-gl-style-spec';
 import { createMapEffectHook } from '../../helpers';
 import { basicStyle } from '../styles/basicStyle';
 import { outdoorStyle } from '../styles/outdoorStyle';
-import {
-  outdoorFadedStyle,
-  OUTDOOR_FADED_ROUTE_LAYERS,
-} from '../styles/outdoorFadedStyle';
+import { outdoorFadedStyle } from '../styles/outdoorFadedStyle';
 import { osmappLayers } from '../../LayerSwitcher/osmappLayers';
 import { getRasterStyle } from '../styles/rasterStyle';
 import { DEFAULT_MAP } from '../../../config.mjs';
@@ -22,7 +19,7 @@ import { EMPTY_GEOJSON_SOURCE, OSMAPP_SPRITE } from '../consts';
 import { fetchCrags } from '../../../services/fetchCrags';
 import { intl } from '../../../services/intl';
 import { Layer } from '../../utils/MapStateContext';
-import { setUpHover, setUpHoverHighlight } from './featureHover';
+import { setUpHover } from './featureHover';
 import { isUrlForRasterLayer, layersWithOsmId } from '../helpers';
 import { Theme } from '../../../helpers/theme';
 import { addIndoorEqual, removeIndoorEqual } from './indoor';
@@ -188,10 +185,6 @@ export const useUpdateStyle = createMapEffectHook(
     map.addControl(languageControl);
 
     setUpHover(map, layersWithOsmId(style));
-
-    if (key === 'outdoorFaded') {
-      setUpHoverHighlight(map, OUTDOOR_FADED_ROUTE_LAYERS);
-    }
 
     if (mapLoaded && overlays.includes('indoor')) {
       addIndoorEqual();

--- a/src/components/Map/styles/outdoorFadedStyle.ts
+++ b/src/components/Map/styles/outdoorFadedStyle.ts
@@ -140,6 +140,10 @@ const fadeStyleColors = (style: StyleSpecification): StyleSpecification => {
     if (!paint) {
       continue;
     }
+    // Symbol layers with an `icon-color` but no explicit `text-color` render default black
+    if (paint['icon-color'] && !paint['text-color']) {
+      paint['text-color'] = 'rgba(0, 0, 0, 1)';
+    }
     Object.keys(paint)
       .filter((key) => key.endsWith('color'))
       .forEach((key) => {

--- a/src/components/Map/styles/outdoorFadedStyle.ts
+++ b/src/components/Map/styles/outdoorFadedStyle.ts
@@ -8,8 +8,14 @@ import { outdoorStyle } from './outdoorStyle';
 
 // How strongly to mute: blend each color towards its own gray (desaturate) and
 // then a touch towards white (lighten). 0 = keep original, 1 = full effect.
-const DESATURATE = 0.7;
-const LIGHTEN = 0.4;
+type FadeConfig = { desaturate: number; lighten: number };
+
+// Default muting for the basemap so it recedes into the background.
+const DEFAULT_FADE: FadeConfig = { desaturate: 0.7, lighten: 0.4 };
+
+// Hiking trails keep their hue (no desaturation) so the colour coding stays
+// readable – they are only lightened a bit so they don't shout over the map.
+const HIKE_ROUTES_FADE: FadeConfig = { desaturate: 0, lighten: 0.4 };
 
 type Rgba = { r: number; g: number; b: number; a: number };
 
@@ -91,15 +97,18 @@ const parseColor = (input: string): Rgba | null => {
   return null;
 };
 
-const fadeColorString = (input: string): string => {
+const fadeColorString = (
+  input: string,
+  { desaturate, lighten }: FadeConfig,
+): string => {
   const c = parseColor(input);
   if (!c) {
     return input;
   }
   const gray = 0.299 * c.r + 0.587 * c.g + 0.114 * c.b;
   const mute = (channel: number) => {
-    const desaturated = channel * (1 - DESATURATE) + gray * DESATURATE;
-    return desaturated * (1 - LIGHTEN) + 255 * LIGHTEN;
+    const desaturated = channel * (1 - desaturate) + gray * desaturate;
+    return desaturated * (1 - lighten) + 255 * lighten;
   };
   const r = clampChannel(mute(c.r));
   const g = clampChannel(mute(c.g));
@@ -112,16 +121,16 @@ const fadeColorString = (input: string): string => {
 // whole value and fade any color string we meet; everything else passes through
 // (expression operators, zoom stops, opacities, …) because it won't parse as a
 // color.
-const fadeColorValue = (value: unknown): unknown => {
+const fadeColorValue = (value: unknown, config: FadeConfig): unknown => {
   if (typeof value === 'string') {
-    return fadeColorString(value);
+    return fadeColorString(value, config);
   }
   if (Array.isArray(value)) {
-    return value.map(fadeColorValue);
+    return value.map((v) => fadeColorValue(v, config));
   }
   if (value && typeof value === 'object') {
     return Object.fromEntries(
-      Object.entries(value).map(([k, v]) => [k, fadeColorValue(v)]),
+      Object.entries(value).map(([k, v]) => [k, fadeColorValue(v, config)]),
     );
   }
   return value;
@@ -137,9 +146,7 @@ const fadeStyleColors = (style: StyleSpecification): StyleSpecification => {
     if (!paint) {
       continue;
     }
-    if (HIKE_ROUTES.test(layer.id)) {
-      continue;
-    }
+    const config = HIKE_ROUTES.test(layer.id) ? HIKE_ROUTES_FADE : DEFAULT_FADE;
     // Symbol layers with an `icon-color` but no explicit `text-color` render default black
     if (paint['icon-color'] && !paint['text-color']) {
       paint['text-color'] = 'rgba(0, 0, 0, 1)';
@@ -147,7 +154,7 @@ const fadeStyleColors = (style: StyleSpecification): StyleSpecification => {
     Object.keys(paint)
       .filter((key) => key.endsWith('color'))
       .forEach((key) => {
-        paint[key] = fadeColorValue(paint[key]);
+        paint[key] = fadeColorValue(paint[key], config);
       });
   }
   return faded;

--- a/src/components/Map/styles/outdoorFadedStyle.ts
+++ b/src/components/Map/styles/outdoorFadedStyle.ts
@@ -127,24 +127,42 @@ const fadeColorValue = (value: unknown): unknown => {
   return value;
 };
 
-// Hiking and cycling route lines should stay vivid (they are the point of the
-// outdoor map), so their layers are excluded from the muting.
-const KEEP_ORIGINAL_COLORS = /^(trail|bicycle)_/;
+// Hiking and cycling route lines are the point of the outdoor map. They are
+// muted like everything else by default, but light up to their full original
+// color on hover (see `feature-state` below + `setUpHoverHighlight`).
+const ROUTE_LAYERS = /^(trail|bicycle)_/;
+
+const HOVER = ['boolean', ['feature-state', 'hover'], false];
+
+// Same as a plain color, but driven by hover: full color when hovered, faded
+// otherwise. Only simple color strings get the hover treatment; stops/
+// expressions fall back to a plain fade (routes only use string colors).
+const fadeColorValueWithHover = (value: unknown): unknown => {
+  if (typeof value === 'string') {
+    const faded = fadeColorString(value);
+    return faded === value ? value : ['case', HOVER, value, faded];
+  }
+  return fadeColorValue(value);
+};
+
+export const OUTDOOR_FADED_ROUTE_LAYERS = outdoorStyle.layers
+  .filter((layer) => ROUTE_LAYERS.test(layer.id))
+  .map((layer) => layer.id);
 
 const fadeStyleColors = (style: StyleSpecification): StyleSpecification => {
   const faded = cloneDeep(style);
   faded.layers.forEach((layer) => {
-    if (KEEP_ORIGINAL_COLORS.test(layer.id)) {
-      return;
-    }
     const paint = (layer as { paint?: Record<string, unknown> }).paint;
     if (!paint) {
       return;
     }
+    const transform = ROUTE_LAYERS.test(layer.id)
+      ? fadeColorValueWithHover
+      : fadeColorValue;
     Object.keys(paint)
       .filter((key) => key.endsWith('color'))
       .forEach((key) => {
-        paint[key] = fadeColorValue(paint[key]);
+        paint[key] = transform(paint[key]);
       });
   });
   return faded;

--- a/src/components/Map/styles/outdoorFadedStyle.ts
+++ b/src/components/Map/styles/outdoorFadedStyle.ts
@@ -133,11 +133,11 @@ const HIKE_ROUTES = /^trail_(?!longdistance)/;
 const fadeStyleColors = (style: StyleSpecification): StyleSpecification => {
   const faded = cloneDeep(style);
   for (const layer of faded.layers) {
-    if (HIKE_ROUTES.test(layer.id)) {
-      continue;
-    }
     const paint = (layer as { paint?: Record<string, unknown> }).paint;
     if (!paint) {
+      continue;
+    }
+    if (HIKE_ROUTES.test(layer.id)) {
       continue;
     }
     // Symbol layers with an `icon-color` but no explicit `text-color` render default black

--- a/src/components/Map/styles/outdoorFadedStyle.ts
+++ b/src/components/Map/styles/outdoorFadedStyle.ts
@@ -127,42 +127,24 @@ const fadeColorValue = (value: unknown): unknown => {
   return value;
 };
 
-// Hiking and cycling route lines are the point of the outdoor map. They are
-// muted like everything else by default, but light up to their full original
-// color on hover (see `feature-state` below + `setUpHoverHighlight`).
-const ROUTE_LAYERS = /^(trail|bicycle)_/;
-
-const HOVER = ['boolean', ['feature-state', 'hover'], false];
-
-// Same as a plain color, but driven by hover: full color when hovered, faded
-// otherwise. Only simple color strings get the hover treatment; stops/
-// expressions fall back to a plain fade (routes only use string colors).
-const fadeColorValueWithHover = (value: unknown): unknown => {
-  if (typeof value === 'string') {
-    const faded = fadeColorString(value);
-    return faded === value ? value : ['case', HOVER, value, faded];
-  }
-  return fadeColorValue(value);
-};
-
-export const OUTDOOR_FADED_ROUTE_LAYERS = outdoorStyle.layers
-  .filter((layer) => ROUTE_LAYERS.test(layer.id))
-  .map((layer) => layer.id);
+// Hiking and cycling route lines should stay vivid (they are the point of the
+// outdoor map), so their layers are excluded from the muting.
+const KEEP_ORIGINAL_COLORS = /^(trail|bicycle)_/;
 
 const fadeStyleColors = (style: StyleSpecification): StyleSpecification => {
   const faded = cloneDeep(style);
   faded.layers.forEach((layer) => {
+    if (KEEP_ORIGINAL_COLORS.test(layer.id)) {
+      return;
+    }
     const paint = (layer as { paint?: Record<string, unknown> }).paint;
     if (!paint) {
       return;
     }
-    const transform = ROUTE_LAYERS.test(layer.id)
-      ? fadeColorValueWithHover
-      : fadeColorValue;
     Object.keys(paint)
       .filter((key) => key.endsWith('color'))
       .forEach((key) => {
-        paint[key] = transform(paint[key]);
+        paint[key] = fadeColorValue(paint[key]);
       });
   });
   return faded;

--- a/src/components/Map/styles/outdoorFadedStyle.ts
+++ b/src/components/Map/styles/outdoorFadedStyle.ts
@@ -127,9 +127,16 @@ const fadeColorValue = (value: unknown): unknown => {
   return value;
 };
 
+// Hiking and cycling route lines should stay vivid (they are the point of the
+// outdoor map), so their layers are excluded from the muting.
+const KEEP_ORIGINAL_COLORS = /^(trail|bicycle)_/;
+
 const fadeStyleColors = (style: StyleSpecification): StyleSpecification => {
   const faded = cloneDeep(style);
   faded.layers.forEach((layer) => {
+    if (KEEP_ORIGINAL_COLORS.test(layer.id)) {
+      return;
+    }
     const paint = (layer as { paint?: Record<string, unknown> }).paint;
     if (!paint) {
       return;

--- a/src/components/Map/styles/outdoorFadedStyle.ts
+++ b/src/components/Map/styles/outdoorFadedStyle.ts
@@ -129,12 +129,12 @@ const fadeColorValue = (value: unknown): unknown => {
 
 // Hiking and cycling route lines should stay vivid (they are the point of the
 // outdoor map), so their layers are excluded from the muting.
-const KEEP_ORIGINAL_COLORS = /^(trail|bicycle)_/;
+const HIKE_ROUTES = /^(trail)_/;
 
 const fadeStyleColors = (style: StyleSpecification): StyleSpecification => {
   const faded = cloneDeep(style);
   faded.layers.forEach((layer) => {
-    if (KEEP_ORIGINAL_COLORS.test(layer.id)) {
+    if (HIKE_ROUTES.test(layer.id)) {
       return;
     }
     const paint = (layer as { paint?: Record<string, unknown> }).paint;

--- a/src/components/Map/styles/outdoorFadedStyle.ts
+++ b/src/components/Map/styles/outdoorFadedStyle.ts
@@ -127,7 +127,8 @@ const fadeColorValue = (value: unknown): unknown => {
   return value;
 };
 
-const HIKE_ROUTES = /^(trail)_/;
+// Keep the color-coded hiking trails vivid from zoom 12+ (lesser zooms are "longdistance")
+const HIKE_ROUTES = /^trail_(?!longdistance)/;
 
 const fadeStyleColors = (style: StyleSpecification): StyleSpecification => {
   const faded = cloneDeep(style);

--- a/src/components/Map/styles/outdoorFadedStyle.ts
+++ b/src/components/Map/styles/outdoorFadedStyle.ts
@@ -1,0 +1,150 @@
+import cloneDeep from 'lodash/cloneDeep';
+import { StyleSpecification } from 'maplibre-gl';
+import { outdoorStyle } from './outdoorStyle';
+
+// "Outdoor faded" reuses the exact same output of `outdoorStyle`, but runs every
+// color through a muting function so the basemap recedes into the background
+// (useful as a backdrop for climbing/trail overlays).
+
+// How strongly to mute: blend each color towards its own gray (desaturate) and
+// then a touch towards white (lighten). 0 = keep original, 1 = full effect.
+const DESATURATE = 0.6;
+const LIGHTEN = 0.15;
+
+type Rgba = { r: number; g: number; b: number; a: number };
+
+const clampChannel = (n: number) => Math.max(0, Math.min(255, Math.round(n)));
+
+const hueToRgb = (p: number, q: number, t: number) => {
+  let tt = t;
+  if (tt < 0) tt += 1;
+  if (tt > 1) tt -= 1;
+  if (tt < 1 / 6) return p + (q - p) * 6 * tt;
+  if (tt < 1 / 2) return q;
+  if (tt < 2 / 3) return p + (q - p) * (2 / 3 - tt) * 6;
+  return p;
+};
+
+const hslToRgb = (h: number, s: number, l: number) => {
+  if (s === 0) {
+    const v = l * 255;
+    return { r: v, g: v, b: v };
+  }
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+  const hk = h / 360;
+  return {
+    r: hueToRgb(p, q, hk + 1 / 3) * 255,
+    g: hueToRgb(p, q, hk) * 255,
+    b: hueToRgb(p, q, hk - 1 / 3) * 255,
+  };
+};
+
+// Parses the color notations actually used in outdoorStyle: rgb(a), hsl(a) and
+// #hex. Returns null for anything else (e.g. named colors used in filters), so
+// those are left untouched.
+const parseColor = (input: string): Rgba | null => {
+  const str = input.trim();
+
+  const hex = str.match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i);
+  if (hex) {
+    const h = hex[1];
+    const full =
+      h.length === 3
+        ? h
+            .split('')
+            .map((c) => c + c)
+            .join('')
+        : h;
+    return {
+      r: parseInt(full.slice(0, 2), 16),
+      g: parseInt(full.slice(2, 4), 16),
+      b: parseInt(full.slice(4, 6), 16),
+      a: 1,
+    };
+  }
+
+  const rgb = str.match(
+    /^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)\s*(?:,\s*([\d.]+)\s*)?\)$/i,
+  );
+  if (rgb) {
+    return {
+      r: parseFloat(rgb[1]),
+      g: parseFloat(rgb[2]),
+      b: parseFloat(rgb[3]),
+      a: rgb[4] !== undefined ? parseFloat(rgb[4]) : 1,
+    };
+  }
+
+  const hsl = str.match(
+    /^hsla?\(\s*([\d.]+)\s*,\s*([\d.]+)%\s*,\s*([\d.]+)%\s*(?:,\s*([\d.]+)\s*)?\)$/i,
+  );
+  if (hsl) {
+    const { r, g, b } = hslToRgb(
+      parseFloat(hsl[1]),
+      parseFloat(hsl[2]) / 100,
+      parseFloat(hsl[3]) / 100,
+    );
+    return { r, g, b, a: hsl[4] !== undefined ? parseFloat(hsl[4]) : 1 };
+  }
+
+  return null;
+};
+
+const fadeColorString = (input: string): string => {
+  const c = parseColor(input);
+  if (!c) {
+    return input;
+  }
+  const gray = 0.299 * c.r + 0.587 * c.g + 0.114 * c.b;
+  const mute = (channel: number) => {
+    const desaturated = channel * (1 - DESATURATE) + gray * DESATURATE;
+    return desaturated * (1 - LIGHTEN) + 255 * LIGHTEN;
+  };
+  const r = clampChannel(mute(c.r));
+  const g = clampChannel(mute(c.g));
+  const b = clampChannel(mute(c.b));
+  return `rgba(${r}, ${g}, ${b}, ${c.a})`;
+};
+
+// A maplibre color paint property can be a plain string, a legacy
+// `{ stops: [[zoom, color], ...] }` function, or an expression array. Walk the
+// whole value and fade any color string we meet; everything else passes through
+// (expression operators, zoom stops, opacities, …) because it won't parse as a
+// color.
+const fadeColorValue = (value: unknown): unknown => {
+  if (typeof value === 'string') {
+    return fadeColorString(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map(fadeColorValue);
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([k, v]) => [k, fadeColorValue(v)]),
+    );
+  }
+  return value;
+};
+
+const fadeStyleColors = (style: StyleSpecification): StyleSpecification => {
+  const faded = cloneDeep(style);
+  faded.layers.forEach((layer) => {
+    const paint = (layer as { paint?: Record<string, unknown> }).paint;
+    if (!paint) {
+      return;
+    }
+    Object.keys(paint)
+      .filter((key) => key.endsWith('color'))
+      .forEach((key) => {
+        paint[key] = fadeColorValue(paint[key]);
+      });
+  });
+  return faded;
+};
+
+export const outdoorFadedStyle = {
+  ...fadeStyleColors(outdoorStyle),
+  id: 'outdoorFaded',
+  name: 'Outdoor faded',
+} as StyleSpecification;

--- a/src/components/Map/styles/outdoorFadedStyle.ts
+++ b/src/components/Map/styles/outdoorFadedStyle.ts
@@ -127,26 +127,24 @@ const fadeColorValue = (value: unknown): unknown => {
   return value;
 };
 
-// Hiking and cycling route lines should stay vivid (they are the point of the
-// outdoor map), so their layers are excluded from the muting.
 const HIKE_ROUTES = /^(trail)_/;
 
 const fadeStyleColors = (style: StyleSpecification): StyleSpecification => {
   const faded = cloneDeep(style);
-  faded.layers.forEach((layer) => {
+  for (const layer of faded.layers) {
     if (HIKE_ROUTES.test(layer.id)) {
-      return;
+      continue;
     }
     const paint = (layer as { paint?: Record<string, unknown> }).paint;
     if (!paint) {
-      return;
+      continue;
     }
     Object.keys(paint)
       .filter((key) => key.endsWith('color'))
       .forEach((key) => {
         paint[key] = fadeColorValue(paint[key]);
       });
-  });
+  }
   return faded;
 };
 

--- a/src/components/Map/styles/outdoorFadedStyle.ts
+++ b/src/components/Map/styles/outdoorFadedStyle.ts
@@ -8,8 +8,8 @@ import { outdoorStyle } from './outdoorStyle';
 
 // How strongly to mute: blend each color towards its own gray (desaturate) and
 // then a touch towards white (lighten). 0 = keep original, 1 = full effect.
-const DESATURATE = 0.6;
-const LIGHTEN = 0.15;
+const DESATURATE = 0.7;
+const LIGHTEN = 0.4;
 
 type Rgba = { r: number; g: number; b: number; a: number };
 

--- a/src/components/Map/styles/outdoorFadedStyle.ts
+++ b/src/components/Map/styles/outdoorFadedStyle.ts
@@ -8,14 +8,8 @@ import { outdoorStyle } from './outdoorStyle';
 
 // How strongly to mute: blend each color towards its own gray (desaturate) and
 // then a touch towards white (lighten). 0 = keep original, 1 = full effect.
-type FadeConfig = { desaturate: number; lighten: number };
-
-// Default muting for the basemap so it recedes into the background.
-const DEFAULT_FADE: FadeConfig = { desaturate: 0.7, lighten: 0.4 };
-
-// Hiking trails keep their hue (no desaturation) so the colour coding stays
-// readable – they are only lightened a bit so they don't shout over the map.
-const HIKE_ROUTES_FADE: FadeConfig = { desaturate: 0, lighten: 0.4 };
+const DESATURATE = 0.7;
+const LIGHTEN = 0.4;
 
 type Rgba = { r: number; g: number; b: number; a: number };
 
@@ -97,18 +91,15 @@ const parseColor = (input: string): Rgba | null => {
   return null;
 };
 
-const fadeColorString = (
-  input: string,
-  { desaturate, lighten }: FadeConfig,
-): string => {
+const fadeColorString = (input: string): string => {
   const c = parseColor(input);
   if (!c) {
     return input;
   }
   const gray = 0.299 * c.r + 0.587 * c.g + 0.114 * c.b;
   const mute = (channel: number) => {
-    const desaturated = channel * (1 - desaturate) + gray * desaturate;
-    return desaturated * (1 - lighten) + 255 * lighten;
+    const desaturated = channel * (1 - DESATURATE) + gray * DESATURATE;
+    return desaturated * (1 - LIGHTEN) + 255 * LIGHTEN;
   };
   const r = clampChannel(mute(c.r));
   const g = clampChannel(mute(c.g));
@@ -121,16 +112,16 @@ const fadeColorString = (
 // whole value and fade any color string we meet; everything else passes through
 // (expression operators, zoom stops, opacities, …) because it won't parse as a
 // color.
-const fadeColorValue = (value: unknown, config: FadeConfig): unknown => {
+const fadeColorValue = (value: unknown): unknown => {
   if (typeof value === 'string') {
-    return fadeColorString(value, config);
+    return fadeColorString(value);
   }
   if (Array.isArray(value)) {
-    return value.map((v) => fadeColorValue(v, config));
+    return value.map(fadeColorValue);
   }
   if (value && typeof value === 'object') {
     return Object.fromEntries(
-      Object.entries(value).map(([k, v]) => [k, fadeColorValue(v, config)]),
+      Object.entries(value).map(([k, v]) => [k, fadeColorValue(v)]),
     );
   }
   return value;
@@ -146,7 +137,9 @@ const fadeStyleColors = (style: StyleSpecification): StyleSpecification => {
     if (!paint) {
       continue;
     }
-    const config = HIKE_ROUTES.test(layer.id) ? HIKE_ROUTES_FADE : DEFAULT_FADE;
+    if (HIKE_ROUTES.test(layer.id)) {
+      continue;
+    }
     // Symbol layers with an `icon-color` but no explicit `text-color` render default black
     if (paint['icon-color'] && !paint['text-color']) {
       paint['text-color'] = 'rgba(0, 0, 0, 1)';
@@ -154,7 +147,7 @@ const fadeStyleColors = (style: StyleSpecification): StyleSpecification => {
     Object.keys(paint)
       .filter((key) => key.endsWith('color'))
       .forEach((key) => {
-        paint[key] = fadeColorValue(paint[key], config);
+        paint[key] = fadeColorValue(paint[key]);
       });
   }
   return faded;

--- a/src/locales/cs.js
+++ b/src/locales/cs.js
@@ -515,6 +515,7 @@ export default {
 
   'layers.basic': 'Základní',
   'layers.outdoor': 'Outdoorová',
+  'layers.outdoor_faded': 'Outdoorová tlumená',
   'layers.mtb': 'MTB',
   'layers.snow': 'Zimní',
   'layers.carto': 'OSM Carto',

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -224,6 +224,7 @@ export default {
   'layers.basic': 'Standard',
   'layers.makina_africa': 'OpenPlaceGuide Afrika',
   'layers.outdoor': 'Outdoor',
+  'layers.outdoor_faded': 'Outdoor gedämpft',
   'layers.mtb': 'MTB',
   'layers.snow': 'Schnee',
   'layers.carto': 'OSM Carto',

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -577,6 +577,7 @@ export default {
   'layers.basic': 'Basic',
   'layers.makina_africa': 'OpenPlaceGuide Africa',
   'layers.outdoor': 'Outdoor',
+  'layers.outdoor_faded': 'Outdoor faded',
   'layers.mtb': 'MTB',
   'layers.snow': 'Snow',
   'layers.carto': 'OSM Carto',


### PR DESCRIPTION
Adds new layer for clearer display of climbing overlay.

"Outdoor faded" fades everything down, only hike routes in zoom 12+ are preserved, because they are used for navigation to the climbing crags.