### PR TITLE
layers: keep roads vivid in Outdoor faded

### DIFF
--- a/src/components/Map/styles/outdoorFadedStyle.ts
+++ b/src/components/Map/styles/outdoorFadedStyle.ts
@@ -130,6 +130,10 @@ const fadeColorValue = (value: unknown): unknown => {
 // Keep the color-coded hiking trails vivid from zoom 12+ (lesser zooms are "longdistance")
 const HIKE_ROUTES = /^trail_(?!longdistance)/;
 
+// Keep the road network (motorways, major & minor roads incl. their tunnels)
+// at full color so it stays usable for navigating to the crags.
+const ROADS = /^(road_(minor|major|motorway)|tunnel_(road_(minor|major)|motorway))$/;
+
 const fadeStyleColors = (style: StyleSpecification): StyleSpecification => {
   const faded = cloneDeep(style);
   for (const layer of faded.layers) {
@@ -137,7 +141,7 @@ const fadeStyleColors = (style: StyleSpecification): StyleSpecification => {
     if (!paint) {
       continue;
     }
-    if (HIKE_ROUTES.test(layer.id)) {
+    if (HIKE_ROUTES.test(layer.id) || ROADS.test(layer.id)) {
       continue;
     }
     // Symbol layers with an `icon-color` but no explicit `text-color` render default black

--- a/src/components/Map/styles/outdoorFadedStyle.ts
+++ b/src/components/Map/styles/outdoorFadedStyle.ts
@@ -132,7 +132,8 @@ const HIKE_ROUTES = /^trail_(?!longdistance)/;
 
 // Keep the road network (motorways, major & minor roads incl. their tunnels)
 // at full color so it stays usable for navigating to the crags.
-const ROADS = /^(road_(minor|major|motorway)|tunnel_(road_(minor|major)|motorway))$/;
+const ROADS =
+  /^(road_(minor|major|motorway)|tunnel_(road_(minor|major)|motorway))$/;
 
 const fadeStyleColors = (style: StyleSpecification): StyleSpecification => {
   const faded = cloneDeep(style);


### PR DESCRIPTION
Roads are now kept at full color in "Outdoor faded", same as the hike routes, because they are used for navigation to the climbing crags.