### PR TITLE
fix: Show outdoor map as default

### DIFF
--- a/src/components/LayerSwitcher/osmappLayers.tsx
+++ b/src/components/LayerSwitcher/osmappLayers.tsx
@@ -78,14 +78,14 @@ export const osmappLayers: Layers = {
     bboxes: [africaBbox],
   },
   outdoor: {
-    name: t('layers.outdoor_faded'),
+    name: t('layers.outdoor'),
     type: 'basemap',
     Icon: FilterHdrIcon,
     attribution: ['maptiler', 'osm'],
     // https://api.maptiler.com/tiles/outdoor/tiles.json?key=xxx .planettime="1703030400000",
   },
   outdoorFull: {
-    name: t('layers.outdoor'),
+    name: t('layers.outdoor_faded'),
     type: 'basemap',
     Icon: FilterHdrIcon,
     attribution: ['maptiler', 'osm'],

--- a/src/components/Map/behaviour/useUpdateStyle.tsx
+++ b/src/components/Map/behaviour/useUpdateStyle.tsx
@@ -52,10 +52,10 @@ const getBaseStyle = (key: string, currentTheme: Theme): StyleSpecification => {
     return makinaAfricaStyle;
   }
   if (key === 'outdoor') {
-    return outdoorFadedStyle;
+    return outdoorStyle;
   }
   if (key === 'outdoorFull') {
-    return outdoorStyle;
+    return outdoorFadedStyle;
   }
   if (key === 'shortbread') {
     return currentTheme === 'dark'


### PR DESCRIPTION
<!-- Please, remove any section which is not applicable/useful. -->

### Description

### Example links

### Screenshots

<!-- consider using smaller images, eg. <img src="url" width="500"> instead of ![](url) -->

### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)
