### PR TITLE
layers: Revert outdoorFaded default layer change from #63

### DIFF
--- a/src/components/LayerSwitcher/osmappLayers.tsx
+++ b/src/components/LayerSwitcher/osmappLayers.tsx
@@ -52,14 +52,14 @@ export const osmappLayers: Layers = {
     Icon: FilterHdrIcon,
     attribution: ['maptiler', 'osm'],
   },
-  outdoorFull: {
-    name: t('layers.outdoor'),
+  outdoorFaded: {
+    name: t('layers.outdoor_faded'),
     type: 'basemap',
     Icon: FilterHdrIcon,
     attribution: ['maptiler', 'osm'],
   },
   outdoor: {
-    name: t('layers.outdoor_faded'),
+    name: t('layers.outdoor'),
     type: 'basemap',
     Icon: FilterHdrIcon,
     attribution: ['maptiler', 'osm'],

--- a/src/components/LayerSwitcher/osmappLayers.tsx
+++ b/src/components/LayerSwitcher/osmappLayers.tsx
@@ -52,18 +52,18 @@ export const osmappLayers: Layers = {
     Icon: FilterHdrIcon,
     attribution: ['maptiler', 'osm'],
   },
-  outdoorFaded: {
-    name: t('layers.outdoor_faded'),
-    type: 'basemap',
-    Icon: FilterHdrIcon,
-    attribution: ['maptiler', 'osm'],
-  },
   outdoor: {
     name: t('layers.outdoor'),
     type: 'basemap',
     Icon: FilterHdrIcon,
     attribution: ['maptiler', 'osm'],
     // https://api.maptiler.com/tiles/outdoor/tiles.json?key=xxx .planettime="1703030400000",
+  },
+  outdoorFaded: {
+    name: t('layers.outdoor_faded'),
+    type: 'basemap',
+    Icon: FilterHdrIcon,
+    attribution: ['maptiler', 'osm'],
   },
   s1: { type: 'spacer' },
   carto: {

--- a/src/components/Map/behaviour/useUpdateStyle.tsx
+++ b/src/components/Map/behaviour/useUpdateStyle.tsx
@@ -53,10 +53,10 @@ const getBaseStyle = (key: string, currentTheme: Theme): StyleSpecification => {
     return makinaAfricaStyle;
   }
   if (key === 'outdoor') {
-    return outdoorFadedStyle;
-  }
-  if (key === 'outdoorFull') {
     return outdoorStyle;
+  }
+  if (key === 'outdoorFaded') {
+    return outdoorFadedStyle;
   }
   if (key === 'tourist') {
     return touristStyle;


### PR DESCRIPTION
Restores the original semantics: `outdoor` key uses the full colorful
outdoorStyle, and the faded variant uses the `outdoorFaded` key again.