### PR TITLE
feat(climbing-tiles): add database export API + download route

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,3 +1,4 @@
 db.sqlite
 db.sqlite-shm
 db.sqlite-wal
+exports/

--- a/pages/api/climbing-tiles/export.ts
+++ b/pages/api/climbing-tiles/export.ts
@@ -1,0 +1,23 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getOrCreateExport } from '../../../src/server/climbing-tiles/exportDatabase';
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).send('Method Not Allowed');
+    return;
+  }
+
+  try {
+    if (!process.env.NEXT_PUBLIC_ENABLE_CLIMBING_TILES) {
+      throw new Error('NEXT_PUBLIC_ENABLE_CLIMBING_TILES must be on');
+    }
+
+    const fileName = await getOrCreateExport();
+
+    res.redirect(302, `/download/${fileName}`);
+  } catch (err) {
+    console.error(err); // eslint-disable-line no-console
+    res.status(500).send(String(err));
+  }
+};

--- a/pages/download/[file].tsx
+++ b/pages/download/[file].tsx
@@ -1,0 +1,43 @@
+import type { GetServerSideProps } from 'next';
+import { createReadStream, statSync } from 'fs';
+import { getExportFilePath } from '../../src/server/climbing-tiles/exportDatabase';
+
+const CACHE_MAX_AGE_SECONDS = 5 * 60; // matches the export regeneration interval
+
+const Download = () => null;
+
+export const getServerSideProps: GetServerSideProps = async ({ query, res }) => {
+  const raw = query.file;
+  const fileName = Array.isArray(raw) ? raw[0] : raw;
+
+  const filePath = fileName ? getExportFilePath(fileName) : null;
+  if (!filePath) {
+    res.statusCode = 404;
+    res.end('Not found');
+    return { props: {} };
+  }
+
+  const stat = statSync(filePath);
+
+  res.setHeader('Content-Type', 'application/vnd.sqlite3');
+  res.setHeader('Content-Disposition', `attachment; filename="${fileName}"`);
+  res.setHeader('Content-Length', stat.size);
+  res.setHeader('Last-Modified', stat.mtime.toUTCString());
+  res.setHeader(
+    'Expires',
+    new Date(Date.now() + CACHE_MAX_AGE_SECONDS * 1000).toUTCString(),
+  );
+  res.setHeader('Cache-Control', `public, max-age=${CACHE_MAX_AGE_SECONDS}`);
+
+  await new Promise<void>((resolve, reject) => {
+    const stream = createReadStream(filePath);
+    stream.on('error', reject);
+    res.on('finish', resolve);
+    res.on('error', reject);
+    stream.pipe(res);
+  });
+
+  return { props: {} };
+};
+
+export default Download;

--- a/pages/download/[file].tsx
+++ b/pages/download/[file].tsx
@@ -6,7 +6,10 @@ const CACHE_MAX_AGE_SECONDS = 5 * 60; // matches the export regeneration interva
 
 const Download = () => null;
 
-export const getServerSideProps: GetServerSideProps = async ({ query, res }) => {
+export const getServerSideProps: GetServerSideProps = async ({
+  query,
+  res,
+}) => {
   const raw = query.file;
   const fileName = Array.isArray(raw) ? raw[0] : raw;
 

--- a/src/server/climbing-tiles/exportDatabase.ts
+++ b/src/server/climbing-tiles/exportDatabase.ts
@@ -1,10 +1,4 @@
-import {
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  statSync,
-  unlinkSync,
-} from 'fs';
+import { existsSync, mkdirSync, readdirSync, statSync, unlinkSync } from 'fs';
 import path from 'path';
 import { format } from 'date-fns';
 import { getDb } from '../db/db';
@@ -17,7 +11,8 @@ const MAX_AGE_MS = 5 * 60 * 1000; // regenerate only if the newest export is old
 const KEEP_FILES = 3; // keep only the last 3 exports, delete the rest
 
 // only filenames we produce ourselves – also guards the download route against path traversal
-export const EXPORT_FILE_REGEX = /^openclimbing_[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{6}\.sqlite$/;
+export const EXPORT_FILE_REGEX =
+  /^openclimbing_[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{6}\.sqlite$/;
 
 type ExportFile = { name: string; path: string; mtimeMs: number };
 

--- a/src/server/climbing-tiles/exportDatabase.ts
+++ b/src/server/climbing-tiles/exportDatabase.ts
@@ -1,0 +1,80 @@
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  statSync,
+  unlinkSync,
+} from 'fs';
+import path from 'path';
+import { format } from 'date-fns';
+import { getDb } from '../db/db';
+
+const EXPORT_DIR = path.resolve(process.cwd(), 'data/exports');
+const FILE_PREFIX = 'openclimbing_';
+const FILE_SUFFIX = '.sqlite';
+
+const MAX_AGE_MS = 5 * 60 * 1000; // regenerate only if the newest export is older than 5 minutes
+const KEEP_FILES = 3; // keep only the last 3 exports, delete the rest
+
+// only filenames we produce ourselves – also guards the download route against path traversal
+export const EXPORT_FILE_REGEX = /^openclimbing_[0-9]{4}-[0-9]{2}-[0-9]{2}_[0-9]{6}\.sqlite$/;
+
+type ExportFile = { name: string; path: string; mtimeMs: number };
+
+const listExportFiles = (): ExportFile[] => {
+  if (!existsSync(EXPORT_DIR)) {
+    return [];
+  }
+  return readdirSync(EXPORT_DIR)
+    .filter((name) => EXPORT_FILE_REGEX.test(name))
+    .map((name) => {
+      const filePath = path.join(EXPORT_DIR, name);
+      return { name, path: filePath, mtimeMs: statSync(filePath).mtimeMs };
+    })
+    .sort((a, b) => b.mtimeMs - a.mtimeMs); // newest first
+};
+
+const pruneOldExports = () => {
+  for (const file of listExportFiles().slice(KEEP_FILES)) {
+    unlinkSync(file.path);
+  }
+};
+
+const createExport = async (): Promise<string> => {
+  mkdirSync(EXPORT_DIR, { recursive: true });
+  const fileName = `${FILE_PREFIX}${format(new Date(), 'yyyy-MM-dd_HHmmss')}${FILE_SUFFIX}`;
+
+  // Online backup – produces one consistent .sqlite file with all WAL data merged in,
+  // so we don't have to deal with the separate -wal / -shm files.
+  await getDb().backup(path.join(EXPORT_DIR, fileName));
+
+  pruneOldExports();
+  return fileName;
+};
+
+/**
+ * Returns the filename of a fresh-enough export, creating a new one if the latest
+ * export is missing or older than 5 minutes. Keeps only the last 3 files on disk.
+ */
+export const getOrCreateExport = async (): Promise<string> => {
+  const [newest] = listExportFiles();
+  if (newest && Date.now() - newest.mtimeMs < MAX_AGE_MS) {
+    return newest.name;
+  }
+  return createExport();
+};
+
+/**
+ * Resolves a requested filename to an existing export path, or null if the name is
+ * invalid (path traversal, unknown pattern) or the file doesn't exist.
+ */
+export const getExportFilePath = (fileName: string): string | null => {
+  if (!EXPORT_FILE_REGEX.test(fileName)) {
+    return null;
+  }
+  const filePath = path.join(EXPORT_DIR, fileName);
+  if (path.dirname(filePath) !== EXPORT_DIR || !existsSync(filePath)) {
+    return null;
+  }
+  return filePath;
+};


### PR DESCRIPTION
Add POST /api/climbing-tiles/export which produces a consistent single-file
snapshot of the WAL-mode SQLite database via better-sqlite3's online backup
API (merges -wal data into one .sqlite file).

- regenerates only if the newest export is missing or older than 5 minutes
- keeps only the last 3 exports, prunes the rest
- redirects to /download/openclimbing_<date>_<time>.sqlite

Add pages/download/[file] route serving the export with proper download
headers: Content-Disposition (attachment + filename), Content-Length,
Last-Modified, Expires and Cache-Control. Filenames are validated against a
strict regex to prevent path traversal.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016pYTcqX3ra7wqKgmooLG4G