### PR TITLE
climbing-tiles: store tags + members, add /get feature endpoint

### DIFF
--- a/pages/api/climbing-tiles/get.ts
+++ b/pages/api/climbing-tiles/get.ts
@@ -1,14 +1,15 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { addCorsAndCache } from '../../../src/server/climbing-tiles/addCorsAndCache';
 import {
-  decodeMapId,
   getClimbingFeature,
+  parseFeatureId,
 } from '../../../src/server/climbing-tiles/getClimbingFeature';
 import { OsmType } from '../../../src/services/types';
 
 const OSM_TYPES: OsmType[] = ['node', 'way', 'relation'];
 
-// Accepts either ?osmType=node&osmId=123 or ?id=<mapId> (e.g. from the map tiles)
+// Accepts ?id=<id> where id is an OSM URL id (`way/123`), a short id (`w123`)
+// or a mapId (`1231`). Alternatively ?osmType=node&osmId=123.
 const parseParams = (
   query: NextApiRequest['query'],
 ): { osmType: OsmType; osmId: number } => {
@@ -23,12 +24,14 @@ const parseParams = (
   }
 
   if (id) {
-    const { type, id: osm } = decodeMapId(Number(id));
+    const { type, id: osm } = parseFeatureId(id);
     return { osmType: type, osmId: osm };
   }
 
   if (!osmType || !osmId) {
-    throw new Error('Provide either `id` (mapId) or `osmType` + `osmId`');
+    throw new Error(
+      'Provide `id` (OSM url id `way/123`, short id `w123` or mapId) or `osmType` + `osmId`',
+    );
   }
   if (!OSM_TYPES.includes(osmType as OsmType)) {
     throw new Error(`Invalid osmType: ${osmType}`);
@@ -42,7 +45,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   try {
     const { osmType, osmId } = parseParams(req.query);
 
-    const feature = getClimbingFeature(osmType, osmId);
+    const feature = await getClimbingFeature(osmType, osmId);
 
     res.status(200).setHeader('Content-Type', 'application/json').send(feature);
   } catch (err) {

--- a/pages/api/climbing-tiles/get.ts
+++ b/pages/api/climbing-tiles/get.ts
@@ -1,0 +1,52 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { addCorsAndCache } from '../../../src/server/climbing-tiles/addCorsAndCache';
+import {
+  decodeMapId,
+  getClimbingFeature,
+} from '../../../src/server/climbing-tiles/getClimbingFeature';
+import { OsmType } from '../../../src/services/types';
+
+const OSM_TYPES: OsmType[] = ['node', 'way', 'relation'];
+
+// Accepts either ?osmType=node&osmId=123 or ?id=<mapId> (e.g. from the map tiles)
+const parseParams = (
+  query: NextApiRequest['query'],
+): { osmType: OsmType; osmId: number } => {
+  const { osmType, osmId, id } = query;
+
+  if (
+    osmType instanceof Array ||
+    osmId instanceof Array ||
+    id instanceof Array
+  ) {
+    throw new Error('Each param must be present only once');
+  }
+
+  if (id) {
+    const { type, id: osm } = decodeMapId(Number(id));
+    return { osmType: type, osmId: osm };
+  }
+
+  if (!osmType || !osmId) {
+    throw new Error('Provide either `id` (mapId) or `osmType` + `osmId`');
+  }
+  if (!OSM_TYPES.includes(osmType as OsmType)) {
+    throw new Error(`Invalid osmType: ${osmType}`);
+  }
+
+  return { osmType: osmType as OsmType, osmId: Number(osmId) };
+};
+
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+  addCorsAndCache(res);
+  try {
+    const { osmType, osmId } = parseParams(req.query);
+
+    const feature = getClimbingFeature(osmType, osmId);
+
+    res.status(200).setHeader('Content-Type', 'application/json').send(feature);
+  } catch (err) {
+    console.error(err); // eslint-disable-line no-console
+    res.status(500).send(String(err));
+  }
+};

--- a/src/server/climbing-tiles/README.md
+++ b/src/server/climbing-tiles/README.md
@@ -34,9 +34,14 @@ We serve ~1000 tile requests/day, server cache HITS are ~1ms, MISSes ~12ms.
 
 - download overpass query – all `climbing=*` or `sport=climbing` elements and all relation members
 - contruct full geometries from OSM elements - `overpassToGeojsons()`
-- filter only relevant data + create SQL records
+- filter only relevant data + create SQL records (each record also stores the raw OSM `tags` as JSON, and for relations the `members` array as JSON)
 - insert the records them in `climbing_features` table
 - clear `climbing_tiles_cache` table
+
+`/api/climbing-tiles/get`:
+
+- returns a single full feature as a GeoJSON `Feature` (`type: 'Feature'`, with `geometry`, `center`, `osmMeta`, raw `tags`, relation `members` and all computable `properties` - decoded histogram, attributes, grade, etc.)
+- identify the feature either by `?osmType=<node|way|relation>&osmId=<id>` or by `?id=<mapId>`
 
 `/api/climbing-tiles/tile`:
 

--- a/src/server/climbing-tiles/README.md
+++ b/src/server/climbing-tiles/README.md
@@ -40,8 +40,9 @@ We serve ~1000 tile requests/day, server cache HITS are ~1ms, MISSes ~12ms.
 
 `/api/climbing-tiles/get`:
 
-- returns a single full feature as a GeoJSON `Feature` (`type: 'Feature'`, with `geometry`, `center`, `osmMeta`, raw `tags`, relation `members` and all computable `properties` - decoded histogram, attributes, grade, etc.)
-- identify the feature either by `?osmType=<node|way|relation>&osmId=<id>` or by `?id=<mapId>`
+- returns a single full feature as a GeoJSON `Feature` (`type: 'Feature'`) built only from the local SQLite DB - no overpass/OSM call
+- identify the feature by `?id=<id>` where `id` is an OSM url id (`way/123`), a short id (`w123`) or a mapId (`1231`); or by `?osmType=<node|way|relation>&osmId=<id>`
+- computed/included fields: `geometry`, `center`, `osmMeta`, raw `tags`, relation `members`, resolved `memberFeatures` (recursive tree from DB) and `parentFeatures` (parentId chain), `imageDefs` (photos / topo paths, merged from members), `countryCode` (root feature) and `properties` (decoded histogram, attributes, grade, routeCount, ...)
 
 `/api/climbing-tiles/tile`:
 

--- a/src/server/climbing-tiles/buildTileGeojson.ts
+++ b/src/server/climbing-tiles/buildTileGeojson.ts
@@ -41,7 +41,7 @@ const optimizeFeaturesToGrid = (
   return grid.flat().filter((f) => f !== null);
 };
 
-const convertOsmIdToMapId = (apiId: OsmId) => {
+export const convertOsmIdToMapId = (apiId: OsmId) => {
   const osmToMapType = { node: 0, way: 1, relation: 4 };
   return parseInt(`${apiId.id}${osmToMapType[apiId.type]}`, 10);
 };
@@ -56,7 +56,7 @@ const getAttributeProperties = (record: ClimbingFeaturesRow) => ({
   familyFriendly: record.familyFriendly ? true : undefined,
 });
 
-const getProperties = (
+export const getProperties = (
   record: ClimbingFeaturesRow,
 ): ClimbingTilesProperties => {
   const { type, parentId } = record;

--- a/src/server/climbing-tiles/getClimbingFeature.ts
+++ b/src/server/climbing-tiles/getClimbingFeature.ts
@@ -2,9 +2,17 @@ import { Geometry } from 'geojson';
 import { getDb } from '../db/db';
 import { ClimbingFeaturesRow } from '../db/types';
 import { ClimbingFeatureFull } from '../../types';
-import { OsmType } from '../../services/types';
+import { Feature, OsmType } from '../../services/types';
+import { getApiId } from '../../services/helpers';
 import { convertOsmIdToMapId, getProperties } from './buildTileGeojson';
 import { decodeHistogram } from './overpass/histogram';
+import {
+  getImageDefs,
+  mergeMemberImageDefs,
+} from '../../services/images/getImageDefs';
+import { getCountryCode } from '../../services/osm/getCountryCode';
+
+const OSM_TYPES: OsmType[] = ['node', 'way', 'relation'];
 
 const mapTypeToOsm: Record<string, OsmType> = {
   '0': 'node',
@@ -22,40 +30,146 @@ export const decodeMapId = (mapId: number): { type: OsmType; id: number } => {
   return { type, id: Number(str.slice(0, -1)) };
 };
 
-export const getClimbingFeature = (
-  osmType: OsmType,
-  osmId: number,
-): ClimbingFeatureFull => {
-  const row = getDb()
+/**
+ * Parses the `id` query param. Accepts:
+ *  - OSM URL id:  `way/123`, `node/5`, `relation/9`
+ *  - short id:    `w123`, `n5`, `r9`
+ *  - mapId:       `1231` (numeric, as used in the vector tiles)
+ */
+export const parseFeatureId = (raw: string): { type: OsmType; id: number } => {
+  const s = String(raw).trim();
+
+  if (s.includes('/')) {
+    const [typeStr, idStr] = s.split('/');
+    const type = typeStr.toLowerCase() as OsmType;
+    const id = Number(idStr);
+    if (!OSM_TYPES.includes(type) || !Number.isFinite(id)) {
+      throw new Error(`Invalid OSM URL id: ${s}`);
+    }
+    return { type, id };
+  }
+
+  if (/^[nwr]/i.test(s)) {
+    const { type, id } = getApiId(s);
+    if (!type || !Number.isFinite(id)) {
+      throw new Error(`Invalid short id: ${s}`);
+    }
+    return { type, id };
+  }
+
+  if (/^\d+$/.test(s)) {
+    return decodeMapId(Number(s));
+  }
+
+  throw new Error(`Cannot parse feature id: ${s}`);
+};
+
+const getRow = (osmType: OsmType, osmId: number) =>
+  getDb()
     .prepare<
       [string, number],
       ClimbingFeaturesRow
     >(`SELECT * FROM climbing_features WHERE "osmType" = ? AND "osmId" = ?`)
     .get(osmType, osmId);
 
-  if (!row) {
-    throw new Error(`Feature ${osmType}/${osmId} not found`);
-  }
+const buildGeometry = (row: ClimbingFeaturesRow): Geometry =>
+  row.line
+    ? { type: 'LineString', coordinates: JSON.parse(row.line) }
+    : { type: 'Point', coordinates: [row.lon, row.lat] };
 
-  const { line, lon, lat, tags, members, histogramCode } = row;
-
-  const geometry: Geometry = line
-    ? { type: 'LineString', coordinates: JSON.parse(line) }
-    : { type: 'Point', coordinates: [lon, lat] };
-
-  const properties = {
-    ...getProperties(row),
-    histogram: histogramCode ? decodeHistogram(histogramCode) : undefined,
-  };
+const buildBaseFeature = (row: ClimbingFeaturesRow): ClimbingFeatureFull => {
+  const { osmType, osmId, lon, lat, tags, members, histogramCode } = row;
+  const center: [number, number] = [lon, lat];
+  const parsedTags = tags ? JSON.parse(tags) : {};
 
   return {
     type: 'Feature',
     id: convertOsmIdToMapId({ type: osmType, id: osmId }),
     osmMeta: { type: osmType, id: osmId },
-    tags: tags ? JSON.parse(tags) : {},
+    tags: parsedTags,
     members: members ? JSON.parse(members) : undefined,
-    center: [lon, lat],
-    geometry,
-    properties,
+    center,
+    geometry: buildGeometry(row),
+    imageDefs: getImageDefs(parsedTags, osmType, center),
+    properties: {
+      ...getProperties(row),
+      histogram: histogramCode ? decodeHistogram(histogramCode) : undefined,
+    },
   };
+};
+
+// Resolves relation members to full features from the DB (recursive tree).
+const buildMemberTree = (
+  members: ClimbingFeatureFull['members'],
+  visited: Set<string>,
+): ClimbingFeatureFull[] => {
+  const result: ClimbingFeatureFull[] = [];
+  for (const { type, ref } of members ?? []) {
+    const row = getRow(type, ref);
+    if (!row) continue; // member not in climbing DB (e.g. geometry-only node)
+
+    const feature = buildBaseFeature(row);
+    const key = `${type}/${ref}`;
+    if (!visited.has(key)) {
+      visited.add(key);
+      if (feature.members?.length) {
+        feature.memberFeatures = buildMemberTree(feature.members, visited);
+        mergeMemberImageDefs(feature as unknown as Feature);
+      }
+    }
+    result.push(feature);
+  }
+  return result;
+};
+
+// Walks the parentId chain upwards (parentId is always a relation osmId).
+const buildParentChain = (
+  parentId: number | undefined,
+  visited: Set<string>,
+): ClimbingFeatureFull[] => {
+  const result: ClimbingFeatureFull[] = [];
+  let pid = parentId;
+  while (pid) {
+    const key = `relation/${pid}`;
+    if (visited.has(key)) break;
+    visited.add(key);
+
+    const row = getRow('relation', pid);
+    if (!row) break;
+
+    result.push(buildBaseFeature(row));
+    pid = row.parentId ?? undefined;
+  }
+  return result;
+};
+
+export const getClimbingFeature = async (
+  osmType: OsmType,
+  osmId: number,
+): Promise<ClimbingFeatureFull> => {
+  const row = getRow(osmType, osmId);
+  if (!row) {
+    throw new Error(`Feature ${osmType}/${osmId} not found`);
+  }
+
+  const feature = buildBaseFeature(row);
+  const visited = new Set<string>([`${osmType}/${osmId}`]);
+
+  if (feature.members?.length) {
+    feature.memberFeatures = buildMemberTree(feature.members, visited);
+    mergeMemberImageDefs(feature as unknown as Feature);
+  }
+
+  if (row.parentId) {
+    feature.parentFeatures = buildParentChain(row.parentId, visited);
+  }
+
+  const countryCode = await getCountryCode({
+    center: feature.center,
+  } as Feature);
+  if (countryCode) {
+    feature.countryCode = countryCode;
+  }
+
+  return feature;
 };

--- a/src/server/climbing-tiles/getClimbingFeature.ts
+++ b/src/server/climbing-tiles/getClimbingFeature.ts
@@ -1,0 +1,61 @@
+import { Geometry } from 'geojson';
+import { getDb } from '../db/db';
+import { ClimbingFeaturesRow } from '../db/types';
+import { ClimbingFeatureFull } from '../../types';
+import { OsmType } from '../../services/types';
+import { convertOsmIdToMapId, getProperties } from './buildTileGeojson';
+import { decodeHistogram } from './overpass/histogram';
+
+const mapTypeToOsm: Record<string, OsmType> = {
+  '0': 'node',
+  '1': 'way',
+  '4': 'relation',
+};
+
+// reverse of convertOsmIdToMapId() - last digit is the osm type marker
+export const decodeMapId = (mapId: number): { type: OsmType; id: number } => {
+  const str = String(mapId);
+  const type = mapTypeToOsm[str.slice(-1)];
+  if (!type) {
+    throw new Error(`Invalid mapId: ${mapId}`);
+  }
+  return { type, id: Number(str.slice(0, -1)) };
+};
+
+export const getClimbingFeature = (
+  osmType: OsmType,
+  osmId: number,
+): ClimbingFeatureFull => {
+  const row = getDb()
+    .prepare<
+      [string, number],
+      ClimbingFeaturesRow
+    >(`SELECT * FROM climbing_features WHERE "osmType" = ? AND "osmId" = ?`)
+    .get(osmType, osmId);
+
+  if (!row) {
+    throw new Error(`Feature ${osmType}/${osmId} not found`);
+  }
+
+  const { line, lon, lat, tags, members, histogramCode } = row;
+
+  const geometry: Geometry = line
+    ? { type: 'LineString', coordinates: JSON.parse(line) }
+    : { type: 'Point', coordinates: [lon, lat] };
+
+  const properties = {
+    ...getProperties(row),
+    histogram: histogramCode ? decodeHistogram(histogramCode) : undefined,
+  };
+
+  return {
+    type: 'Feature',
+    id: convertOsmIdToMapId({ type: osmType, id: osmId }),
+    osmMeta: { type: osmType, id: osmId },
+    tags: tags ? JSON.parse(tags) : {},
+    members: members ? JSON.parse(members) : undefined,
+    center: [lon, lat],
+    geometry,
+    properties,
+  };
+};

--- a/src/server/climbing-tiles/refreshClimbingTilesHelpers.ts
+++ b/src/server/climbing-tiles/refreshClimbingTilesHelpers.ts
@@ -92,6 +92,8 @@ export const recordsFactory = (log: (message: string) => void) => {
       climbingTypes: encodeList(attributes.climbingTypes),
       inclinations: encodeList(attributes.inclinations),
       familyFriendly: attributes.familyFriendly ? 1 : 0,
+      tags: feature.tags ? JSON.stringify(feature.tags) : null,
+      members: feature.members ? JSON.stringify(feature.members) : null,
     };
 
     records.push(record);

--- a/src/server/db/db.ts
+++ b/src/server/db/db.ts
@@ -125,6 +125,28 @@ const runPendingMigrations = (db: Database) => {
 
     console.log(`Database ${DB_PATH} migrated from version 4 to 5`); // eslint-disable-line no-console
   }
+  if (getDbVersion(db) === 5) {
+    db.transaction(() => {
+      const existingColumns = db
+        .prepare<[], { name: string }>(`PRAGMA table_info(climbing_features)`)
+        .all()
+        .map((c) => c.name);
+      const newColumns: [string, string][] = [
+        ['tags', 'TEXT'],
+        ['members', 'TEXT'],
+      ];
+      for (const [name, sqlType] of newColumns) {
+        if (!existingColumns.includes(name)) {
+          db.exec(
+            `ALTER TABLE climbing_features ADD COLUMN "${name}" ${sqlType};`,
+          );
+        }
+      }
+      db.pragma('user_version = 6');
+    })();
+
+    console.log(`Database ${DB_PATH} migrated from version 5 to 6`); // eslint-disable-line no-console
+  }
 };
 
 // global to allow hot-reload in dev
@@ -140,10 +162,10 @@ export function getDb() {
     if (getDbVersion(db) === 0) {
       db.transaction(() => {
         db.exec(readFileSync(SCHEMA_PATH, 'utf8'));
-        db.pragma('user_version = 5');
+        db.pragma('user_version = 6');
       })();
 
-      console.log(`Database ${DB_PATH} initialized to version 5`); // eslint-disable-line no-console
+      console.log(`Database ${DB_PATH} initialized to version 6`); // eslint-disable-line no-console
     }
 
     store.db = db;

--- a/src/server/db/schema.sql
+++ b/src/server/db/schema.sql
@@ -1,4 +1,4 @@
--- SQLite schema v5 (see db.ts migrations when bumping user_version)
+-- SQLite schema v6 (see db.ts migrations when bumping user_version)
 
 CREATE TABLE climbing_features
 (
@@ -20,7 +20,9 @@ CREATE TABLE climbing_features
   materials       TEXT, -- comma-joined climbing:rock values
   "climbingTypes" TEXT, -- comma-joined climbing types (sport, trad, ...)
   inclinations    TEXT, -- comma-joined inclinations (slab, vertical, ...)
-  "familyFriendly" INTEGER -- bool
+  "familyFriendly" INTEGER, -- bool
+  tags            TEXT, -- JSON object of all OSM tags
+  members         TEXT -- JSON array of relation members (relations only)
 );
 
 CREATE TABLE climbing_tiles_cache

--- a/src/server/db/types.ts
+++ b/src/server/db/types.ts
@@ -19,6 +19,8 @@ export type ClimbingFeaturesRow = {
   climbingTypes?: string | null; // comma-joined climbing types
   inclinations?: string | null; // comma-joined inclinations
   familyFriendly?: number | null; // bool
+  tags?: string | null; // JSON object of all OSM tags
+  members?: string | null; // JSON array of relation members (relations only)
 };
 
 export type ClimbingStatsRow = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,18 @@ export type ClimbingTilesFeature = GeojsonFeature<
   ClimbingTilesProperties
 >;
 
+// Full single feature returned by GET /api/climbing-tiles/get
+export type ClimbingFeatureFull = {
+  type: 'Feature';
+  id: number; // mapId
+  osmMeta: { type: OsmType; id: number };
+  tags: Record<string, string>;
+  members?: { type: OsmType; ref: number; role: string }[]; // relations only
+  center: [number, number];
+  geometry: Geometry;
+  properties: ClimbingTilesProperties & { histogram?: number[] };
+};
+
 export type ClimbingTick = {
   id: number;
   osmUserId: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { Feature as GeojsonFeature, Geometry } from 'geojson';
-import { OsmType } from './services/types';
+import { ImageDef, OsmType } from './services/types';
 
 export type Setter<T> = React.Dispatch<React.SetStateAction<T>>;
 
@@ -55,12 +55,18 @@ export type ClimbingTilesFeature = GeojsonFeature<
 >;
 
 // Full single feature returned by GET /api/climbing-tiles/get
+// Shaped as a GeoJSON Feature, aligned with the osmapp `Feature` type
+// (src/services/types.ts) for the fields computable from the tiles SQLite DB.
 export type ClimbingFeatureFull = {
   type: 'Feature';
   id: number; // mapId
   osmMeta: { type: OsmType; id: number };
   tags: Record<string, string>;
   members?: { type: OsmType; ref: number; role: string }[]; // relations only
+  memberFeatures?: ClimbingFeatureFull[]; // children resolved from DB (tree)
+  parentFeatures?: ClimbingFeatureFull[]; // parent chain resolved from DB
+  imageDefs?: ImageDef[]; // photos / topo image definitions from tags + center
+  countryCode?: string; // ISO 3166-1 lowercase (root feature only)
   center: [number, number];
   geometry: Geometry;
   properties: ClimbingTilesProperties & { histogram?: number[] };


### PR DESCRIPTION
Refresh now persists each feature's raw OSM tags (and relation members)
as JSON columns in climbing_features (schema v6 migration). Adds the
GET /api/climbing-tiles/get endpoint returning the full GeoJSON Feature
with geometry, center, osmMeta, tags, members and all computable
properties (decoded histogram, attributes, grade, ...).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013agSrifV5rJahb7n9DAzzJ