### PR TITLE
Replace async backup with VACUUM INTO for database exports

### DIFF
--- a/src/server/climbing-tiles/exportDatabase.ts
+++ b/src/server/climbing-tiles/exportDatabase.ts
@@ -35,13 +35,14 @@ const pruneOldExports = () => {
   }
 };
 
-const createExport = async (): Promise<string> => {
+const createExport = (): string => {
   mkdirSync(EXPORT_DIR, { recursive: true });
   const fileName = `${FILE_PREFIX}${format(new Date(), 'yyyy-MM-dd_HHmmss')}${FILE_SUFFIX}`;
 
-  // Online backup – produces one consistent .sqlite file with all WAL data merged in,
+  // VACUUM INTO produces a compact copy (skips free pages) with WAL data merged in,
   // so we don't have to deal with the separate -wal / -shm files.
-  await getDb().backup(path.join(EXPORT_DIR, fileName));
+  const exportPath = path.join(EXPORT_DIR, fileName);
+  getDb().exec(`VACUUM INTO '${exportPath.replace(/'/g, "''")}'`);
 
   pruneOldExports();
   return fileName;


### PR DESCRIPTION
### Description

Changed the database export mechanism from using the async `backup()` method to the synchronous `VACUUM INTO` SQL command. This approach:

- Removes unnecessary async/await overhead since the operation is already synchronous at the SQL level
- Uses `VACUUM INTO` which produces a compact database copy by skipping free pages
- Simplifies the function signature by removing the Promise return type
- Properly escapes single quotes in the file path to prevent SQL injection

The functionality remains the same—creating a consistent SQLite export file with all WAL data merged in—but with a more direct and efficient implementation.

### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)

https://claude.ai/code/session_014stK3vAPpNy4vwQjXkYKNj