### PR TITLE
fix: Not save protection paths to osm

### DIFF
--- a/src/components/FeaturePanel/Climbing/utils/pathUtils.ts
+++ b/src/components/FeaturePanel/Climbing/utils/pathUtils.ts
@@ -12,6 +12,13 @@ const hasTrailingColon = (s: string) => s.includes(':');
 const stripTrailingColon = (s: string) =>
   hasTrailingColon(s) ? s.slice(0, -1) : s;
 
+// Coordinates are stored as percentage fractions (0..1). Even the largest
+// Commons photos are only a few thousand px wide, so 5 decimals already means
+// sub-pixel precision – anything more just bloats the tag value.
+const COORD_DECIMAL_PLACES = 5;
+
+const roundCoord = (n: number) => parseFloat(n.toFixed(COORD_DECIMAL_PLACES));
+
 const encodePoint = ({
   x,
   y,
@@ -20,7 +27,7 @@ const encodePoint = ({
   x: number;
   y: number;
   type?: PointType;
-}) => `${x},${y}${type ? T2B[type] : ''}`;
+}) => `${roundCoord(x)},${roundCoord(y)}${type ? T2B[type] : ''}`;
 
 const decodePointToken = (token: string): PathPoint => {
   const [xStr, yWithMaybeCode = ''] = token.split(',', 2);

--- a/src/components/FeaturePanel/Climbing/utils/protectionPathTags.ts
+++ b/src/components/FeaturePanel/Climbing/utils/protectionPathTags.ts
@@ -6,6 +6,11 @@ import { parsePathString, stringifyPath } from './pathUtils';
 export const protectionPathKey = (wikimediaFileKey: string) =>
   `${wikimediaFileKey}:protection_path`;
 
+// Feature flag: standalone protection points are still experimental, so we do
+// not push their `:protection_path` tags to OSM yet. Parsing/displaying them
+// stays enabled – flip this to `true` once we want to persist them again.
+export const SAVE_PROTECTION_PATHS_TO_OSM = false;
+
 export const parseProtectionPointsByPhoto = (
   tags: FeatureTags,
 ): Record<string, PathPoints> => {
@@ -25,6 +30,10 @@ export const getCragProtectionTagPatch = (
   cragTags: FeatureTags,
   protectionByPhoto: Record<string, PathPoints>,
 ): FeatureTags => {
+  if (!SAVE_PROTECTION_PATHS_TO_OSM) {
+    return {};
+  }
+
   const patch: FeatureTags = {};
   getWikimediaCommonsPhotoTags(cragTags).forEach(([fileKey, fileValue]) => {
     const photoPathname = removeFilePrefix(fileValue);


### PR DESCRIPTION
<!-- Please, remove any section which is not applicable/useful. -->

### Description

### Example links

### Screenshots

<!-- consider using smaller images, eg. <img src="url" width="500"> instead of ![](url) -->

### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)
