### PR TITLE
climbing-tiles: optimize /get endpoint

### DIFF
--- a/src/server/climbing-tiles/getClimbingFeature.ts
+++ b/src/server/climbing-tiles/getClimbingFeature.ts
@@ -92,10 +92,9 @@ const getRows = (
     const ids = [...idSet];
     const placeholders = ids.map(() => '?').join(',');
     const rows = getDb()
-      .prepare<
-        [OsmType, ...number[]],
-        ClimbingFeaturesRow
-      >(`SELECT * FROM climbing_features WHERE "osmType" = ? AND "osmId" IN (${placeholders})`)
+      .prepare<[OsmType, ...number[]], ClimbingFeaturesRow>(
+        `SELECT * FROM climbing_features WHERE "osmType" = ? AND "osmId" IN (${placeholders})`,
+      )
       .all(osmType, ...ids);
     for (const row of rows) {
       result.set(`${row.osmType}/${row.osmId}`, row);

--- a/src/server/climbing-tiles/getClimbingFeature.ts
+++ b/src/server/climbing-tiles/getClimbingFeature.ts
@@ -72,6 +72,39 @@ const getRow = (osmType: OsmType, osmId: number) =>
     >(`SELECT * FROM climbing_features WHERE "osmType" = ? AND "osmId" = ?`)
     .get(osmType, osmId);
 
+// Batch variant of getRow() - fetches all members of one relation level with a
+// single query per osmType (`osmId IN (...)`) instead of one query per member.
+// Returns a map keyed by `${osmType}/${osmId}`.
+const getRows = (
+  members: ClimbingFeatureFull['members'],
+): Map<string, ClimbingFeaturesRow> => {
+  const result = new Map<string, ClimbingFeaturesRow>();
+  if (!members?.length) {
+    return result;
+  }
+
+  const idsByType = new Map<OsmType, Set<number>>();
+  for (const { type, ref } of members) {
+    (idsByType.get(type) ?? idsByType.set(type, new Set()).get(type)!).add(ref);
+  }
+
+  for (const [osmType, idSet] of idsByType) {
+    const ids = [...idSet];
+    const placeholders = ids.map(() => '?').join(',');
+    const rows = getDb()
+      .prepare<
+        [OsmType, ...number[]],
+        ClimbingFeaturesRow
+      >(`SELECT * FROM climbing_features WHERE "osmType" = ? AND "osmId" IN (${placeholders})`)
+      .all(osmType, ...ids);
+    for (const row of rows) {
+      result.set(`${row.osmType}/${row.osmId}`, row);
+    }
+  }
+
+  return result;
+};
+
 const buildGeometry = (row: ClimbingFeaturesRow): Geometry =>
   row.line
     ? { type: 'LineString', coordinates: JSON.parse(row.line) }
@@ -104,8 +137,9 @@ const buildMemberTree = (
   visited: Set<string>,
 ): ClimbingFeatureFull[] => {
   const result: ClimbingFeatureFull[] = [];
+  const rows = getRows(members); // one query per osmType, not per member
   for (const { type, ref } of members ?? []) {
-    const row = getRow(type, ref);
+    const row = rows.get(`${type}/${ref}`);
     if (!row) continue; // member not in climbing DB (e.g. geometry-only node)
 
     const feature = buildBaseFeature(row);

--- a/src/server/db/db.ts
+++ b/src/server/db/db.ts
@@ -147,6 +147,19 @@ const runPendingMigrations = (db: Database) => {
 
     console.log(`Database ${DB_PATH} migrated from version 5 to 6`); // eslint-disable-line no-console
   }
+  if (getDbVersion(db) === 6) {
+    db.transaction(() => {
+      // speeds up single feature lookups by (osmType, osmId) - the /get endpoint
+      // resolves relation members recursively and walks the parentId chain, doing
+      // one lookup per member (previously a full table scan of ~76k rows each).
+      db.exec(
+        `CREATE INDEX IF NOT EXISTS idx_climbing_features_osm ON climbing_features ("osmType", "osmId");`,
+      );
+      db.pragma('user_version = 7');
+    })();
+
+    console.log(`Database ${DB_PATH} migrated from version 6 to 7`); // eslint-disable-line no-console
+  }
 };
 
 // global to allow hot-reload in dev
@@ -162,10 +175,10 @@ export function getDb() {
     if (getDbVersion(db) === 0) {
       db.transaction(() => {
         db.exec(readFileSync(SCHEMA_PATH, 'utf8'));
-        db.pragma('user_version = 6');
+        db.pragma('user_version = 7');
       })();
 
-      console.log(`Database ${DB_PATH} initialized to version 6`); // eslint-disable-line no-console
+      console.log(`Database ${DB_PATH} initialized to version 7`); // eslint-disable-line no-console
     }
 
     store.db = db;

--- a/src/server/db/schema.sql
+++ b/src/server/db/schema.sql
@@ -1,4 +1,4 @@
--- SQLite schema v6 (see db.ts migrations when bumping user_version)
+-- SQLite schema v7 (see db.ts migrations when bumping user_version)
 
 CREATE TABLE climbing_features
 (
@@ -24,6 +24,11 @@ CREATE TABLE climbing_features
   tags            TEXT, -- JSON object of all OSM tags
   members         TEXT -- JSON array of relation members (relations only)
 );
+
+-- speeds up single feature lookups by (osmType, osmId) - used heavily by
+-- /api/climbing-tiles/get when it recursively resolves relation members and
+-- walks the parentId chain (getRow() in getClimbingFeature.ts)
+CREATE INDEX idx_climbing_features_osm ON climbing_features ("osmType", "osmId");
 
 CREATE TABLE climbing_tiles_cache
 (


### PR DESCRIPTION
Optimizes load time from 0.7s to 0.04s for full relation.

Roviště r17130099 (735 kB)


Varianta | SQL dotazů | Čas (warm)
-- | -- | --
Před indexem (původní kód, dotaz per member) | 304 | ~0,70 s
Po indexu (dotaz per member) | 304 | ~0,06 s
batchování IN (...), bez indexu | 19 | ~0,25 s
batchování IN (...), s indexem | 19 | ~0,037 s


