### PR TITLE
climbingTiles: use fetchFeature from our DB v2

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -21,6 +21,24 @@ const nextConfig = {
     defaultLocale: 'default',
     localeDetection: false,
   },
+  webpack: (config, { isServer }) => {
+    if (!isServer) {
+      // fetchFeatureFromTiles() dynamically imports the climbing-tiles SQLite
+      // code behind an isServer() guard. Webpack still emits that async chunk
+      // for the browser build, so null out the node-only deps to keep it
+      // compiling (the chunk is never executed client-side).
+      config.resolve.alias = {
+        ...config.resolve.alias,
+        'better-sqlite3': false,
+      };
+      config.resolve.fallback = {
+        ...config.resolve.fallback,
+        fs: false,
+        path: false,
+      };
+    }
+    return config;
+  },
 };
 
 export default withSentryConfig(nextConfig, {

--- a/pages/api/climbing-tiles/get.ts
+++ b/pages/api/climbing-tiles/get.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { addCorsAndCache } from '../../../src/server/climbing-tiles/addCorsAndCache';
 import {
+  ClimbingFeatureNotFoundError,
   getClimbingFeature,
   parseFeatureId,
 } from '../../../src/server/climbing-tiles/getClimbingFeature';
@@ -49,6 +50,10 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 
     res.status(200).setHeader('Content-Type', 'application/json').send(feature);
   } catch (err) {
+    if (err instanceof ClimbingFeatureNotFoundError) {
+      res.status(404).send(String(err));
+      return;
+    }
     console.error(err); // eslint-disable-line no-console
     res.status(500).send(String(err));
   }

--- a/pages/api/og-image.tsx
+++ b/pages/api/og-image.tsx
@@ -8,6 +8,7 @@ import {
   ImageDefFromCenter,
   ImageDefFromTag,
   isTag,
+  OsmId,
 } from '../../src/services/types';
 import { getImageFromApi } from '../../src/services/images/getImageFromApi';
 import { getLogo, ProjectLogo } from '../../src/server/images/logo';
@@ -23,6 +24,7 @@ import { Size } from '../../src/components/FeaturePanel/FeatureImages/types';
 import { getApiId, getShortId } from '../../src/services/helpers';
 import { renderStyledHtml } from '../../src/server/images/renderStyledHtml';
 import { fetchWithMemberFeatures } from '../../src/services/osm/fetchWithMemberFeatures';
+import { getClimbingFeature } from '../../src/server/climbing-tiles/getClimbingFeature';
 import { mockSchemaTranslations } from '../../src/services/tagging/translations';
 import translations from '@openstreetmap/id-tagging-schema/dist/translations/en.json';
 import { intl } from '../../src/services/intl';
@@ -147,6 +149,33 @@ const renderSvg = async (
   };
 };
 
+/**
+ * Loads the feature for the OG image. Fast path reads it from the local
+ * climbing-tiles SQLite DB (no OSM/Overpass round-trip). Falls back to the OSM
+ * full fetch when the feature is not in the DB, on any error, or when the
+ * caller explicitly asks for fresh data (`?fresh=1`).
+ */
+const getOgFeature = async (
+  osmId: OsmId,
+  nocache: boolean,
+): Promise<Feature> => {
+  if (!nocache) {
+    try {
+      return (await getClimbingFeature(
+        osmId.type,
+        osmId.id,
+      )) as unknown as Feature;
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.log(
+        'og-image: climbing-tiles miss, falling back to OSM:',
+        e instanceof Error ? e.message : e,
+      );
+    }
+  }
+  return fetchWithMemberFeatures(osmId, { nocache });
+};
+
 // on vercel node ~800ms in total
 // - api/image: 838ms; fetchFeature: 496ms, getImage: 102ms, renderSvg: 38ms, svg2png: 202ms
 // - api/image: 953ms; fetchFeature: 765ms, getImage: 0ms, renderSvg: 23ms, svg2png: 165ms
@@ -158,7 +187,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 
     const osmId = getApiId(req.query.id as string);
     const nocache = req.query.fresh === '1' || req.query.fresh === 'true';
-    const feature = await fetchWithMemberFeatures(osmId, { nocache }); // TODO
+    const feature = await getOgFeature(osmId, nocache);
     const photoIndex = parsePhotoIndex(req.query.photoIndex);
     const selectedDef = feature.imageDefs?.[photoIndex];
     if (!selectedDef) {

--- a/src/components/App/helpers.ts
+++ b/src/components/App/helpers.ts
@@ -1,7 +1,8 @@
 import * as Sentry from '@sentry/nextjs';
 import nextCookies from 'next-cookies';
 import Cookies from 'js-cookie';
-import { clearFeatureCache, fetchFeature } from '../../services/osm/osmApi';
+import { clearFeatureCache } from '../../services/osm/osmApi';
+import { fetchFeatureFromTiles } from '../../services/osm/fetchFeatureFromTiles';
 import { fetchJson } from '../../services/fetch';
 import { isServer } from '../helpers';
 import { getCoordsFeature } from '../../services/getCoordsFeature';
@@ -109,13 +110,16 @@ export const getInitialFeature = async (
 
   if (isServer()) {
     // we need always fresh OSM element, b/c user can edit a feature and refresh the page
-    // (other requests like overpass may be cached)
+    // (other requests like overpass may be cached) - only matters for the OSM fallback
     clearFeatureCache(apiId);
   }
 
   const t1 = new Date().getTime();
 
-  const initialFeature = await fetchFeature(apiId);
+  // Fast path: read the feature from the climbing-tiles SQLite DB (server) or
+  // the /api/climbing-tiles/get endpoint (browser). Falls back to OSM/Overpass
+  // when the feature is not in the DB (e.g. non-climbing POI) or on any error.
+  const initialFeature = await fetchFeatureFromTiles(apiId);
   saveLastUrl(initialFeature, ctx);
 
   const t2 = new Date().getTime();

--- a/src/server/climbing-tiles/__tests__/getClimbingFeature.test.ts
+++ b/src/server/climbing-tiles/__tests__/getClimbingFeature.test.ts
@@ -1,0 +1,219 @@
+import BetterSqlite3, { type Database } from 'better-sqlite3';
+import { readFileSync } from 'fs';
+import path from 'path';
+import {
+  ClimbingFeatureNotFoundError,
+  getClimbingFeature,
+  parseFeatureId,
+} from '../getClimbingFeature';
+
+// getDb() is replaced by an in-memory SQLite DB seeded below (see buildDummyDb).
+// The var must be prefixed `mock` so jest allows the factory to reference it.
+let mockDb: Database;
+jest.mock('../../db/db', () => ({ getDb: () => mockDb }));
+
+// resolveCountryCode() bundles a large offline dataset - stub it for a fast,
+// deterministic test.
+jest.mock('../../../services/osm/getCountryCode', () => ({
+  getCountryCode: jest.fn().mockResolvedValue('cz'),
+}));
+
+type SeedRow = {
+  type: string;
+  osmType: 'node' | 'way' | 'relation';
+  osmId: number;
+  lon: number;
+  lat: number;
+  nameRaw: string;
+  parentId?: number;
+  line?: [number, number][];
+  tags: Record<string, string>;
+  members?: { type: string; ref: number; role: string }[];
+};
+
+// Minimal but realistic climbing tree:
+//   area (relation) -> crag (relation) -> route (node) + route (way)
+const AREA: SeedRow = {
+  type: 'area',
+  osmType: 'relation',
+  osmId: 100,
+  lon: 14,
+  lat: 50,
+  nameRaw: 'Test Area',
+  tags: {
+    climbing: 'area',
+    name: 'Test Area',
+    sport: 'climbing',
+    type: 'site',
+  },
+  members: [{ type: 'relation', ref: 200, role: '' }],
+};
+
+const CRAG: SeedRow = {
+  type: 'crag',
+  osmType: 'relation',
+  osmId: 200,
+  lon: 14.01,
+  lat: 50.01,
+  nameRaw: 'Test Crag',
+  parentId: 100,
+  tags: {
+    climbing: 'crag',
+    name: 'Test Crag',
+    sport: 'climbing',
+    type: 'site',
+  },
+  members: [
+    { type: 'node', ref: 300, role: '' },
+    { type: 'way', ref: 400, role: '' },
+  ],
+};
+
+const ROUTE_NODE: SeedRow = {
+  type: 'route',
+  osmType: 'node',
+  osmId: 300,
+  lon: 14.011,
+  lat: 50.011,
+  nameRaw: 'Node Route',
+  parentId: 200,
+  tags: {
+    sport: 'climbing',
+    climbing: 'route_bottom',
+    name: 'Node Route',
+    'climbing:grade:uiaa': '5',
+  },
+};
+
+const ROUTE_WAY: SeedRow = {
+  type: 'route',
+  osmType: 'way',
+  osmId: 400,
+  lon: 14.02,
+  lat: 50.02,
+  nameRaw: 'Way Route',
+  parentId: 200,
+  line: [
+    [14.02, 50.02],
+    [14.021, 50.021],
+  ],
+  tags: { sport: 'climbing', climbing: 'route', name: 'Way Route' },
+};
+
+const buildDummyDb = (rows: SeedRow[]): Database => {
+  const db = new BetterSqlite3(':memory:');
+  const schema = readFileSync(
+    path.resolve(__dirname, '../../db/schema.sql'),
+    'utf8',
+  );
+  db.exec(schema);
+
+  const insert = db.prepare(`
+    INSERT INTO climbing_features
+      (type, lon, lat, "osmType", "osmId", "nameRaw", "parentId", line, tags, members)
+    VALUES
+      (@type, @lon, @lat, @osmType, @osmId, @nameRaw, @parentId, @line, @tags, @members)
+  `);
+  for (const r of rows) {
+    insert.run({
+      type: r.type,
+      lon: r.lon,
+      lat: r.lat,
+      osmType: r.osmType,
+      osmId: r.osmId,
+      nameRaw: r.nameRaw,
+      parentId: r.parentId ?? null,
+      line: r.line ? JSON.stringify(r.line) : null,
+      tags: JSON.stringify(r.tags),
+      members: r.members ? JSON.stringify(r.members) : null,
+    });
+  }
+  return db;
+};
+
+describe('getClimbingFeature (dummy SQLite DB)', () => {
+  beforeEach(() => {
+    mockDb = buildDummyDb([AREA, CRAG, ROUTE_NODE, ROUTE_WAY]);
+  });
+
+  afterEach(() => {
+    mockDb.close();
+  });
+
+  it('resolves a crag relation with member tree and parent chain', async () => {
+    const crag = await getClimbingFeature('relation', 200);
+
+    expect(crag.osmMeta).toEqual({ type: 'relation', id: 200 });
+    expect(crag.tags.name).toBe('Test Crag');
+    expect(crag.center).toEqual([14.01, 50.01]);
+    expect(crag.countryCode).toBe('cz');
+
+    // members resolved from DB (node + way)
+    const memberIds = crag.memberFeatures?.map((m) => m.osmMeta);
+    expect(memberIds).toEqual([
+      { type: 'node', id: 300 },
+      { type: 'way', id: 400 },
+    ]);
+
+    // geometry per member type
+    const node = crag.memberFeatures?.find((m) => m.osmMeta.type === 'node');
+    const way = crag.memberFeatures?.find((m) => m.osmMeta.type === 'way');
+    expect(node?.geometry).toEqual({
+      type: 'Point',
+      coordinates: [14.011, 50.011],
+    });
+    expect(way?.geometry?.type).toBe('LineString');
+
+    // parent chain (crag -> area)
+    expect(crag.parentFeatures?.map((p) => p.osmMeta)).toEqual([
+      { type: 'relation', id: 100 },
+    ]);
+  });
+
+  it('walks the full parentId chain for a route node (crag -> area)', async () => {
+    const route = await getClimbingFeature('node', 300);
+
+    expect(route.osmMeta).toEqual({ type: 'node', id: 300 });
+    expect(route.memberFeatures).toBeUndefined();
+    expect(route.parentFeatures?.map((p) => p.osmMeta)).toEqual([
+      { type: 'relation', id: 200 },
+      { type: 'relation', id: 100 },
+    ]);
+  });
+
+  it('builds a LineString geometry for a way route from `line`', async () => {
+    const way = await getClimbingFeature('way', 400);
+    expect(way.geometry).toEqual({
+      type: 'LineString',
+      coordinates: [
+        [14.02, 50.02],
+        [14.021, 50.021],
+      ],
+    });
+  });
+
+  it('returns only class/subclass in properties (tile props computed on FE)', async () => {
+    const crag = await getClimbingFeature('relation', 200);
+
+    // reduced payload: no routeCount / histogram / gradeTxt / materials ...
+    expect(Object.keys(crag.properties).sort()).toEqual(['class', 'subclass']);
+    expect(crag.properties.class).toBeTruthy();
+    expect(crag.properties).not.toHaveProperty('histogram');
+    expect(crag.properties).not.toHaveProperty('routeCount');
+  });
+
+  it('throws ClimbingFeatureNotFoundError for a feature missing from the DB', async () => {
+    await expect(getClimbingFeature('node', 999999)).rejects.toBeInstanceOf(
+      ClimbingFeatureNotFoundError,
+    );
+  });
+});
+
+describe('parseFeatureId', () => {
+  it('parses OSM url id, short id and mapId', () => {
+    expect(parseFeatureId('way/123')).toEqual({ type: 'way', id: 123 });
+    expect(parseFeatureId('n5')).toEqual({ type: 'node', id: 5 });
+    // mapId: last digit encodes the type (0=node, 1=way, 4=relation)
+    expect(parseFeatureId('2004')).toEqual({ type: 'relation', id: 200 });
+  });
+});

--- a/src/server/climbing-tiles/__tests__/getClimbingFeature.test.ts
+++ b/src/server/climbing-tiles/__tests__/getClimbingFeature.test.ts
@@ -174,7 +174,7 @@ describe('getClimbingFeature (dummy SQLite DB)', () => {
     const route = await getClimbingFeature('node', 300);
 
     expect(route.osmMeta).toEqual({ type: 'node', id: 300 });
-    expect(route.memberFeatures).toBeUndefined();
+    expect(route.memberFeatures).toEqual([]);
     expect(route.parentFeatures?.map((p) => p.osmMeta)).toEqual([
       { type: 'relation', id: 200 },
       { type: 'relation', id: 100 },

--- a/src/server/climbing-tiles/getClimbingFeature.ts
+++ b/src/server/climbing-tiles/getClimbingFeature.ts
@@ -4,15 +4,20 @@ import { ClimbingFeaturesRow } from '../db/types';
 import { ClimbingFeatureFull } from '../../types';
 import { Feature, OsmType } from '../../services/types';
 import { getApiId } from '../../services/helpers';
-import { convertOsmIdToMapId, getProperties } from './buildTileGeojson';
-import { decodeHistogram } from './overpass/histogram';
+import { convertOsmIdToMapId } from './buildTileGeojson';
 import {
   getImageDefs,
   mergeMemberImageDefs,
 } from '../../services/images/getImageDefs';
 import { getCountryCode } from '../../services/osm/getCountryCode';
+import { getPoiClass } from '../../services/getPoiClass';
 
 const OSM_TYPES: OsmType[] = ['node', 'way', 'relation'];
+
+// Thrown when the feature is not present in the climbing SQLite DB (e.g. a
+// non-climbing POI, or data not yet refreshed). The /get endpoint maps it to a
+// 404 so the client can cheaply fall back to the OSM/Overpass path.
+export class ClimbingFeatureNotFoundError extends Error {}
 
 const mapTypeToOsm: Record<string, OsmType> = {
   '0': 'node',
@@ -110,7 +115,7 @@ const buildGeometry = (row: ClimbingFeaturesRow): Geometry =>
     : { type: 'Point', coordinates: [row.lon, row.lat] };
 
 const buildBaseFeature = (row: ClimbingFeaturesRow): ClimbingFeatureFull => {
-  const { osmType, osmId, lon, lat, tags, members, histogramCode } = row;
+  const { osmType, osmId, lon, lat, tags, members } = row;
   const center: [number, number] = [lon, lat];
   const parsedTags = tags ? JSON.parse(tags) : {};
 
@@ -123,10 +128,12 @@ const buildBaseFeature = (row: ClimbingFeaturesRow): ClimbingFeatureFull => {
     center,
     geometry: buildGeometry(row),
     imageDefs: getImageDefs(parsedTags, osmType, center),
-    properties: {
-      ...getProperties(row),
-      histogram: histogramCode ? decodeHistogram(histogramCode) : undefined,
-    },
+    // Only class/subclass (for the POI icon), computed from tags - exactly like
+    // osmToFeature(). Tile-only props (routeCount, histogram, grade, materials,
+    // ...) are intentionally NOT sent: the FeaturePanel derives everything it
+    // needs from `tags` + resolved `memberFeatures`, so shipping the precomputed
+    // tile properties would only bloat the payload. Compute them on the FE.
+    properties: getPoiClass(parsedTags),
   };
 };
 
@@ -182,7 +189,9 @@ export const getClimbingFeature = async (
 ): Promise<ClimbingFeatureFull> => {
   const row = getRow(osmType, osmId);
   if (!row) {
-    throw new Error(`Feature ${osmType}/${osmId} not found`);
+    throw new ClimbingFeatureNotFoundError(
+      `Feature ${osmType}/${osmId} not found`,
+    );
   }
 
   const feature = buildBaseFeature(row);

--- a/src/server/climbing-tiles/getClimbingFeature.ts
+++ b/src/server/climbing-tiles/getClimbingFeature.ts
@@ -125,6 +125,10 @@ const buildBaseFeature = (row: ClimbingFeaturesRow): ClimbingFeatureFull => {
     osmMeta: { type: osmType, id: osmId },
     tags: parsedTags,
     members: members ? JSON.parse(members) : undefined,
+    // Always default to [] (like the Overpass path's leaf/visited case) so
+    // consumers can safely iterate memberFeatures without null-guards. It's
+    // overwritten with the resolved children in buildMemberTree() when present.
+    memberFeatures: [],
     center,
     geometry: buildGeometry(row),
     imageDefs: getImageDefs(parsedTags, osmType, center),

--- a/src/services/osm/__tests__/fetchFeatureFromTiles.test.ts
+++ b/src/services/osm/__tests__/fetchFeatureFromTiles.test.ts
@@ -1,0 +1,68 @@
+import { fetchFeatureFromTiles } from '../fetchFeatureFromTiles';
+import { markFeatureAsRecentlyEdited } from '../recentlyEditedFeatures';
+import * as fetch from '../../fetch';
+import * as osmApi from '../osmApi';
+
+// browser path (isServer=false -> hits the /api/climbing-tiles/get endpoint)
+jest.mock('../../../components/helpers', () => ({
+  isServer: () => false,
+  isBrowser: () => true,
+}));
+jest.mock('../../fetch', () => ({ fetchJson: jest.fn() }));
+jest.mock('../osmApi', () => ({
+  fetchFeature: jest.fn(async (apiId) => ({ osmMeta: apiId, __fromOsm: true })),
+}));
+jest.mock('../../tagging/translations', () => ({
+  fetchSchemaTranslations: jest.fn(),
+}));
+jest.mock('../../tagging/idTaggingScheme', () => ({
+  addSchemaToFeature: (f: unknown) => f,
+}));
+
+const fetchJson = fetch.fetchJson as jest.Mock;
+const fetchFeature = osmApi.fetchFeature as jest.Mock;
+
+const tilesFeature = (apiId: { type: string; id: number }) => ({
+  type: 'Feature',
+  osmMeta: apiId,
+  tags: {},
+  center: [14, 50],
+  geometry: { type: 'Point', coordinates: [14, 50] },
+  properties: { class: 'climbing', subclass: 'climbing' },
+});
+
+describe('fetchFeatureFromTiles', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('uses the climbing-tiles endpoint for a normal feature', async () => {
+    fetchJson.mockResolvedValue(tilesFeature({ type: 'node', id: 2 }));
+
+    const feature = await fetchFeatureFromTiles({ type: 'node', id: 2 });
+
+    expect(fetchJson).toHaveBeenCalledWith(
+      expect.stringContaining('/api/climbing-tiles/get?osmType=node&osmId=2'),
+    );
+    expect(fetchFeature).not.toHaveBeenCalled();
+    expect(feature.osmMeta).toEqual({ type: 'node', id: 2 });
+  });
+
+  it('bypasses tiles and fetches fresh OSM for a recently edited feature', async () => {
+    markFeatureAsRecentlyEdited({ type: 'node', id: 1 });
+
+    const feature = await fetchFeatureFromTiles({ type: 'node', id: 1 });
+
+    expect(fetchFeature).toHaveBeenCalledWith({ type: 'node', id: 1 });
+    expect(fetchJson).not.toHaveBeenCalled();
+    expect(feature).toMatchObject({ __fromOsm: true });
+  });
+
+  it('falls back to OSM when the tiles endpoint fails', async () => {
+    fetchJson.mockRejectedValue(new Error('500 Server Error'));
+
+    const feature = await fetchFeatureFromTiles({ type: 'way', id: 3 });
+
+    expect(fetchJson).toHaveBeenCalled();
+    expect(fetchFeature).toHaveBeenCalledWith({ type: 'way', id: 3 });
+    expect(feature).toMatchObject({ __fromOsm: true });
+  });
+});

--- a/src/services/osm/auth/osmApiAuth.ts
+++ b/src/services/osm/auth/osmApiAuth.ts
@@ -11,6 +11,7 @@ import { getApiId, getFullOsmappLink, getUrlOsmId } from '../../helpers';
 import { Feature, FeatureTags, LonLat, OsmId, SuccessInfo } from '../../types';
 import { OSM_WEBSITE } from '../consts';
 import { getFirstExistingId } from '../getFirstExistingId';
+import { markFeatureAsRecentlyEdited } from '../recentlyEditedFeatures';
 import * as api from './api';
 import { getDiffXml } from './getDIffXml';
 import { xmljsBuildOsm } from './xmlHelpers';
@@ -123,6 +124,14 @@ export const saveChanges = async (
 
   // TODO invalidate all changed also in server (?)
   clearFetchCache();
+
+  // Skip the (nightly) climbing-tiles DB for everything we just touched, so the
+  // FeaturePanel shows fresh OSM data right after the edit. See fetchFeatureFromTiles().
+  markFeatureAsRecentlyEdited(original.osmMeta);
+  markFeatureAsRecentlyEdited(firstId);
+  changes.forEach(({ shortId }) =>
+    markFeatureAsRecentlyEdited(getApiId(shortId)),
+  );
 
   return {
     type: 'edit',

--- a/src/services/osm/fetchFeatureFromTiles.ts
+++ b/src/services/osm/fetchFeatureFromTiles.ts
@@ -1,0 +1,71 @@
+import { Feature, OsmId } from '../types';
+import { ClimbingFeatureFull } from '../../types';
+import { fetchJson } from '../fetch';
+import { isServer } from '../../components/helpers';
+import { addSchemaToFeature } from '../tagging/idTaggingScheme';
+import { fetchSchemaTranslations } from '../tagging/translations';
+import { getShortId } from '../helpers';
+import { CLIMBING_TILES_HOST } from './consts';
+import { fetchFeature } from './osmApi';
+import { wasRecentlyEdited } from './recentlyEditedFeatures';
+
+/**
+ * The GET /api/climbing-tiles/get response is already shaped as a GeoJSON
+ * `Feature` (see ClimbingFeatureFull / getClimbingFeature()). The only thing
+ * missing for the FeaturePanel is the derived `schema`, which is computed here
+ * on the FE from `tags` (same as the OSM path in fetchFeature()).
+ */
+const toFeature = async (full: ClimbingFeatureFull): Promise<Feature> => {
+  await fetchSchemaTranslations(); // needed by addSchemaToFeature()
+  return addSchemaToFeature(full as unknown as Feature);
+};
+
+// On the server we read the local SQLite DB directly (no network round-trip).
+// The dynamic import keeps better-sqlite3 out of the client bundle - it is
+// aliased away for the browser build in next.config.mjs.
+const getFromSqlite = async (apiId: OsmId): Promise<ClimbingFeatureFull> => {
+  const { getClimbingFeature } = await import(
+    '../../server/climbing-tiles/getClimbingFeature'
+  );
+  return getClimbingFeature(apiId.type, apiId.id);
+};
+
+const getFromApi = async (apiId: OsmId): Promise<ClimbingFeatureFull> => {
+  const url = `${CLIMBING_TILES_HOST}api/climbing-tiles/get?osmType=${apiId.type}&osmId=${apiId.id}`;
+  return fetchJson<ClimbingFeatureFull>(url);
+};
+
+/**
+ * Fetches a full feature from the climbing-tiles SQLite DB:
+ *  - on the server it calls the select code directly,
+ *  - in the browser it hits the GET /api/climbing-tiles/get endpoint.
+ *
+ * On ANY failure (feature not in DB -> 404, missing db.sqlite / 500, network,
+ * non-climbing POI, ...) it transparently falls back to the original
+ * fetchFeature() which pulls fresh data from OSM / Overpass.
+ *
+ * NOTE: intended only for the initial (SSR / router) feature load. The
+ * EditDialog and the "Reload fresh data from OpenStreetMap" button must keep
+ * using fetchFeature() directly so they always get up-to-date OSM data.
+ */
+export const fetchFeatureFromTiles = async (apiId: OsmId): Promise<Feature> => {
+  // A feature edited in this session must always come fresh from OSM - the
+  // climbing-tiles DB only refreshes nightly and would show the pre-edit state.
+  if (wasRecentlyEdited(apiId)) {
+    return fetchFeature(apiId);
+  }
+
+  try {
+    const full = isServer()
+      ? await getFromSqlite(apiId)
+      : await getFromApi(apiId);
+    return await toFeature(full);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `fetchFeatureFromTiles(${getShortId(apiId)}) falling back to OSM:`,
+      e instanceof Error ? e.message : e,
+    );
+    return fetchFeature(apiId);
+  }
+};

--- a/src/services/osm/recentlyEditedFeatures.ts
+++ b/src/services/osm/recentlyEditedFeatures.ts
@@ -1,0 +1,23 @@
+import { OsmId } from '../types';
+import { getShortId } from '../helpers';
+
+/**
+ * Features the user has edited in THIS browser session (via saveChanges()).
+ *
+ * For these we must NOT serve the climbing-tiles SQLite DB (which only refreshes
+ * nightly) - it would show the pre-edit state. fetchFeatureFromTiles() checks
+ * this registry and always fetches fresh data from OSM instead, so right after
+ * an edit the FeaturePanel shows the updated feature.
+ *
+ * It's an in-memory Set (browser only) that survives client-side router
+ * navigations (the post-save `Router.replace(redirect)`), and is naturally
+ * dropped on a full page reload.
+ */
+const recentlyEdited = new Set<string>();
+
+export const markFeatureAsRecentlyEdited = (apiId: OsmId) => {
+  recentlyEdited.add(getShortId(apiId));
+};
+
+export const wasRecentlyEdited = (apiId: OsmId): boolean =>
+  recentlyEdited.has(getShortId(apiId));

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import { Feature as GeojsonFeature, Geometry } from 'geojson';
-import { ImageDef, OsmType } from './services/types';
+import { FeatureProperties, ImageDef, OsmType } from './services/types';
 
 export type Setter<T> = React.Dispatch<React.SetStateAction<T>>;
 
@@ -69,7 +69,9 @@ export type ClimbingFeatureFull = {
   countryCode?: string; // ISO 3166-1 lowercase (root feature only)
   center: [number, number];
   geometry: Geometry;
-  properties: ClimbingTilesProperties & { histogram?: number[] };
+  // Only class/subclass (POI icon), computed from tags like osmToFeature().
+  // Tile-only props (routeCount, histogram, grade, ...) are computed on the FE.
+  properties: FeatureProperties;
 };
 
 export type ClimbingTick = {


### PR DESCRIPTION
`fetchFeature()` now reads from the SQLite DB. Fallback to OSM/Overpass. 
Followup from #96 (/get endpoint) and #109 (optimize load to 0.04s)

> [!NOTE]
> Already deployed in #111, then reverted because of crashing Frankenjura.



### Description

| Místo | Účel | Změna |
|---|---|---|
| `App/helpers.ts` → `getInitialFeature()` | Initial SSR / router navigace | ✅ **Migrováno** na `fetchFeatureFromTiles()` |
| `pages/api/og-image.tsx` | OG obrázek (dřív `fetchWithMemberFeatures`) | ✅ **Migrováno** (tiles + fallback) |
| `FeatureContext.tsx` → `reloadFeature()` | Tlačítko „Načíst čerstvá data z OSM" | ⛔ **Ponecháno** – vždy fresh OSM |
| `useSaveCragFactory.tsx` | Reload po uložení cragu | ⛔ **Ponecháno** – volá `reloadFeature()` → OSM |
| `osmApi.test.ts` | Testy `fetchFeature` | – beze změny |
| `EditDialog` | volá `fetchFreshItem()` | – beze změny |

### Testing

- prod DB z `POST /api/climbing-tiles/export` (32 MB, 76 202 řádků), ověřeno na reálném cragu `relation/11889282`
- E2e testy s dummy in-memory DB (area + crag + route node + route way)
- Testy `fetchFeatureFromTiles`: tiles cesta, bypass recently-edited → OSM, fallback při chybě.
- Prošel `next build`, celý jest i lint
- getInitialFeature() r17130099 23-57ms




<details>
<summary>prompts</summary>

### Prompt 1

Máme nový endpoint climbing-tiles/get - který vrací celou Featuru.

Mrkni na kód fetchFeature(), kde je použitý a jestli by se dal nějak nahradit aby na clientu používal ten nový endpoint  a na serveru rovnou provolal ten kód který to selectí z SQLITE. Asi bude potřeba ten kód nějak extrahovat na vhodné místo. Aby šel pěkně importovat. Myslím že teď vrací příliš mnoho properties, některé by bylo lepší spočítat až na frontendu. Prozkoumej/oprav/vypiš shrnutí v tabulce.

V případě že failne (500, 404, nebo neexistující db.sqlite etc) tak to může fallbacknout na ten původní kód který to tahá z OSM případně z overpassu.


Taky mrkni jak se vyrábí api/og-image.tsx tam to nahraď taky.

Zkus mi zjistit kde všude se používá to původní fetchFeature. Důležité je aby to neovlivnilo EditDialog, nebo tlačítko "Načíst čerstvá data z OpenStreetMap".

Pořádně to otestuj, stáhni prod db z "POST https://openclimbing.org/api/climbing-tiles/export". A napiš i pár e2e testů s nějakou dummy db. Která bude obsahovat třeba jen minimální climbing area + crag + cestu typu node + cestu typu way.

### Prompt 2

> Po editaci feature ukáže initial load (hard refresh) data z tiles DB. Je to vědomý trade-off za rychlost — čerstvá OSM data zůstávají přes reloadFeature() (tlačítko + auto po uložení). Non-climbing POI v DB nejsou → padnou na 404 → fallback na OSM.

Mohl bys to nějak upravit, aby po dokončení editace se to fetchovalo z čerstvé OSM. Tedy nějak fallbacknout pryč z toho tiles endpointu? Bylo by dobrý aby uživatel po editaci viděl ve FeaturePanelu aktualizovaná data.

### Prompt 3

pusť si dev server a udělej mi screenshot téhle stránky bez puštěného JavaScriptu - jde mi o SSR:

* /relation/17130099
* zkontroluj že to šlo z DB a jak dlouho to trvalo ten request
* a porovnej nakonec screenshot s https://openclimbing.org/relation/17130099

A pak to celý vyresetuj a zkus otevřít /?qd=relation/17130099 - což to načte z clienta bez SSR. A zase screenshot a porovnej.
</details>


---
_Generated by [Claude Code](https://claude.ai/code/session_012iDLMyvjHHinpfCEBG7zN8)_