### PR TITLE
FeaturePanel: add error boundary

### DIFF
--- a/src/components/App/crashOverlay.tsx
+++ b/src/components/App/crashOverlay.tsx
@@ -102,6 +102,29 @@ const recordEntry = (entry: CrashEntry) => {
   console.error('[crashOverlay]', entry.source, entry.message, entry);
 };
 
+/**
+ * Zaznamená React chybu zachycenou lokálním error boundary (např. kolem
+ * FeaturePanelu). Chyba se do window 'error' nedostane (boundary ji pohltí),
+ * takže ji musíme do reportu poslat ručně – ať ji v debug módu vidíme stejně
+ * jako pády zachycené globálním <CrashErrorBoundary>.
+ */
+export const reportReactError = (
+  source: string,
+  error: unknown,
+  componentStack?: string,
+) => {
+  const err = error as { name?: string; message?: string; stack?: string };
+  recordEntry({
+    source,
+    name: err?.name,
+    message: err?.message || String(error),
+    stack: err?.stack,
+    componentStack,
+    time: new Date().toISOString(),
+  });
+  renderVanillaOverlay();
+};
+
 // ---------------------------------------------------------------------------
 // Vanilla DOM overlay (funguje i po unmountu Reactu)
 // ---------------------------------------------------------------------------

--- a/src/components/FeaturePanel/FeaturePanelErrorBoundary.tsx
+++ b/src/components/FeaturePanel/FeaturePanelErrorBoundary.tsx
@@ -6,10 +6,7 @@ import { t } from '../../services/intl';
 import { getReactKey } from '../../services/helpers';
 import { useFeatureContext } from '../utils/FeatureContext';
 import { PanelSidePadding } from '../utils/PanelHelpers';
-import {
-  isCrashDebugEnabled,
-  reportReactError,
-} from '../App/crashOverlay';
+import { isCrashDebugEnabled, reportReactError } from '../App/crashOverlay';
 
 type Props = {
   children: React.ReactNode;

--- a/src/components/FeaturePanel/FeaturePanelErrorBoundary.tsx
+++ b/src/components/FeaturePanel/FeaturePanelErrorBoundary.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import Router from 'next/router';
+import { Alert, AlertTitle, Button } from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import { t } from '../../services/intl';
+import { getReactKey } from '../../services/helpers';
+import { useFeatureContext } from '../utils/FeatureContext';
+import { PanelSidePadding } from '../utils/PanelHelpers';
+import {
+  isCrashDebugEnabled,
+  reportReactError,
+} from '../App/crashOverlay';
+
+type Props = {
+  children: React.ReactNode;
+  // Změna této hodnoty smaže chybový stav – panel se tak sám zotaví, když
+  // uživatel přejde na jinou feature (aniž by se odsud dalo klikat).
+  resetKey: string;
+};
+type State = { hasError: boolean };
+
+/**
+ * Lokální error boundary kolem obsahu FeaturePanelu. Když render panelu spadne,
+ * nespadne celá appka (mapa i navigace zůstanou funkční) – zobrazí se jen
+ * fallback uvnitř panelu a uživatel může kliknout dál.
+ *
+ * V debug módu chybu naopak NEchytáme a necháme ji probublat k celoobrazovkému
+ * <CrashErrorBoundary>, aby šel report pohodlně zkopírovat (viz crashOverlay).
+ */
+class ErrorBoundary extends React.Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    // V debug módu vrátíme false → render zopakuje children, ty spadnou znovu
+    // a React chybu propaguje k nadřazenému <CrashErrorBoundary>.
+    return { hasError: !isCrashDebugEnabled() };
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (this.state.hasError && prevProps.resetKey !== this.props.resetKey) {
+      this.setState({ hasError: false });
+    }
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    // I když chybu tady pohltíme, pošleme ji do reportu (v debug módu ji jinak
+    // zachytí až probublání k CrashErrorBoundary – recordEntry to dedupuje).
+    reportReactError(
+      'feature-panel-boundary',
+      error,
+      info?.componentStack ?? undefined,
+    );
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <PanelSidePadding>
+          <Alert
+            severity="warning"
+            sx={{ my: 2 }}
+            action={
+              <Button
+                color="inherit"
+                size="small"
+                startIcon={<ArrowBackIcon fontSize="inherit" />}
+                onClick={() => Router.back()}
+              >
+                {t('featurepanel.error.back')}
+              </Button>
+            }
+          >
+            <AlertTitle>{t('featurepanel.error.title')}</AlertTitle>
+            {t('featurepanel.error.description')}
+          </Alert>
+        </PanelSidePadding>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export const FeaturePanelErrorBoundary: React.FC = ({ children }) => {
+  const { feature } = useFeatureContext();
+  const resetKey = feature ? getReactKey(feature) : 'none';
+  return <ErrorBoundary resetKey={resetKey}>{children}</ErrorBoundary>;
+};

--- a/src/components/FeaturePanel/FeaturePanelInDrawer.tsx
+++ b/src/components/FeaturePanel/FeaturePanelInDrawer.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import React, { Ref } from 'react';
 import { FeaturePanel } from './FeaturePanel';
+import { FeaturePanelErrorBoundary } from './FeaturePanelErrorBoundary';
 import { Drawer } from '../utils/Drawer';
 import {
   DRAWER_PREVIEW_HEIGHT,
@@ -44,7 +45,9 @@ export const FeaturePanelInDrawer = ({
       collapsedHeight={collapsedHeight}
       scrollRef={scrollRef}
     >
-      <FeaturePanel headingRef={headingRef} />
+      <FeaturePanelErrorBoundary>
+        <FeaturePanel headingRef={headingRef} />
+      </FeaturePanelErrorBoundary>
     </Drawer>
   );
 };

--- a/src/components/FeaturePanel/FeaturePanelOnSide.tsx
+++ b/src/components/FeaturePanel/FeaturePanelOnSide.tsx
@@ -2,6 +2,7 @@ import React, { LegacyRef } from 'react';
 
 import { PanelScrollbars, PanelWrapper } from '../utils/PanelHelpers';
 import { FeaturePanel } from './FeaturePanel';
+import { FeaturePanelErrorBoundary } from './FeaturePanelErrorBoundary';
 import { Scrollbars } from 'react-custom-scrollbars';
 
 type FeaturePanelOnSideProps = {
@@ -12,7 +13,9 @@ export const FeaturePanelOnSide = ({ scrollRef }: FeaturePanelOnSideProps) => {
   return (
     <PanelWrapper>
       <PanelScrollbars scrollRef={scrollRef}>
-        <FeaturePanel />
+        <FeaturePanelErrorBoundary>
+          <FeaturePanel />
+        </FeaturePanelErrorBoundary>
       </PanelScrollbars>
     </PanelWrapper>
   );

--- a/src/components/FeaturePanel/__tests__/FeaturePanelErrorBoundary.test.tsx
+++ b/src/components/FeaturePanel/__tests__/FeaturePanelErrorBoundary.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { FeaturePanelErrorBoundary } from '../FeaturePanelErrorBoundary';
+
+jest.mock('../../../services/intl', () => ({ t: (key: string) => key }));
+
+jest.mock('../../utils/PanelHelpers', () => ({
+  PanelSidePadding: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+jest.mock('../../../services/helpers', () => ({
+  getReactKey: (feature: { id: number }) => String(feature?.id),
+}));
+
+const mockUseFeatureContext = jest.fn();
+jest.mock('../../utils/FeatureContext', () => ({
+  useFeatureContext: () => mockUseFeatureContext(),
+}));
+
+const reportReactError = jest.fn();
+let debugMode = false;
+jest.mock('../../App/crashOverlay', () => ({
+  isCrashDebugEnabled: () => debugMode,
+  reportReactError: (...args: unknown[]) => reportReactError(...args),
+}));
+
+const Boom = ({ explode }: { explode: boolean }) => {
+  if (explode) throw new Error('boom in panel');
+  return <div>panel-content</div>;
+};
+
+describe('FeaturePanelErrorBoundary', () => {
+  let consoleError: jest.SpyInstance;
+
+  beforeEach(() => {
+    debugMode = false;
+    reportReactError.mockClear();
+    mockUseFeatureContext.mockReturnValue({ feature: { id: 1 } });
+    // React logs caught render errors to console.error – silence it.
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it('renders children when nothing throws', () => {
+    render(
+      <FeaturePanelErrorBoundary>
+        <Boom explode={false} />
+      </FeaturePanelErrorBoundary>,
+    );
+
+    expect(screen.queryByText('panel-content')).not.toBeNull();
+  });
+
+  it('shows the fallback and keeps siblings alive when a child throws', () => {
+    render(
+      <>
+        <FeaturePanelErrorBoundary>
+          <Boom explode />
+        </FeaturePanelErrorBoundary>
+        <div>map-still-interactive</div>
+      </>,
+    );
+
+    // Panel body is replaced by the fallback...
+    expect(screen.queryByText('featurepanel.error.title')).not.toBeNull();
+    expect(screen.queryByText('panel-content')).toBeNull();
+    // ...but the rest of the app (e.g. the map) keeps rendering.
+    expect(screen.queryByText('map-still-interactive')).not.toBeNull();
+    expect(reportReactError).toHaveBeenCalledTimes(1);
+  });
+
+  it('recovers when the user navigates to another feature (resetKey change)', () => {
+    const { rerender } = render(
+      <FeaturePanelErrorBoundary>
+        <Boom explode />
+      </FeaturePanelErrorBoundary>,
+    );
+    expect(screen.queryByText('featurepanel.error.title')).not.toBeNull();
+
+    // Different feature -> resetKey changes -> boundary clears its error state.
+    mockUseFeatureContext.mockReturnValue({ feature: { id: 2 } });
+    rerender(
+      <FeaturePanelErrorBoundary>
+        <Boom explode={false} />
+      </FeaturePanelErrorBoundary>,
+    );
+
+    expect(screen.queryByText('panel-content')).not.toBeNull();
+    expect(screen.queryByText('featurepanel.error.title')).toBeNull();
+  });
+
+  it('re-throws in debug mode so the global crash overlay can catch it', () => {
+    debugMode = true;
+
+    expect(() =>
+      render(
+        <FeaturePanelErrorBoundary>
+          <Boom explode />
+        </FeaturePanelErrorBoundary>,
+      ),
+    ).toThrow('boom in panel');
+  });
+});

--- a/src/locales/am.js
+++ b/src/locales/am.js
@@ -35,8 +35,7 @@ export default {
   'featurepanel.error_network': 'ማምጣት አልቻልኩም, የመገናኛ መረብዎን ገመዶች ይመርምሩ',
   'featurepanel.error_deleted': 'ይህ አካል በOpenStreetMap ላይ ተሰርዟል የሚል ምልክት ተደርጎበታል',
   'featurepanel.error.title': 'ይህን ቦታ ሲያሳይ የሆነ ስህተት ተከስቷል።',
-  'featurepanel.error.description':
-    'የተቀረው ካርታ አሁንም ይሰራል። ወደ ኋላ ለመመለስ ወይም ሌላ ቦታ ለመክፈት ይሞክሩ።',
+  'featurepanel.error.description': 'የተቀረው ካርታ አሁንም ይሰራል። ወደ ኋላ ለመመለስ ወይም ሌላ ቦታ ለመክፈት ይሞክሩ።',
   'featurepanel.error.back': 'ተመለስ',
   'featurepanel.history_button': 'ታሪኮች »',
   'featurepanel.details_heading': 'ተጨማሪ መረጃ',

--- a/src/locales/am.js
+++ b/src/locales/am.js
@@ -34,6 +34,10 @@ export default {
   'featurepanel.error_unknown': 'ከOpenStreetMap የተለያዩ ክፍሎችን ለማምጣት ያልታወቀ ስህተት ገጥሞታል',
   'featurepanel.error_network': 'ማምጣት አልቻልኩም, የመገናኛ መረብዎን ገመዶች ይመርምሩ',
   'featurepanel.error_deleted': 'ይህ አካል በOpenStreetMap ላይ ተሰርዟል የሚል ምልክት ተደርጎበታል',
+  'featurepanel.error.title': 'ይህን ቦታ ሲያሳይ የሆነ ስህተት ተከስቷል።',
+  'featurepanel.error.description':
+    'የተቀረው ካርታ አሁንም ይሰራል። ወደ ኋላ ለመመለስ ወይም ሌላ ቦታ ለመክፈት ይሞክሩ።',
+  'featurepanel.error.back': 'ተመለስ',
   'featurepanel.history_button': 'ታሪኮች »',
   'featurepanel.details_heading': 'ተጨማሪ መረጃ',
   'featurepanel.edit_button_title': 'በOpenStreetMap የመረጃ ቋት ውስጥ አርትእ',

--- a/src/locales/cs.js
+++ b/src/locales/cs.js
@@ -359,8 +359,7 @@ export default {
   'featurepanel.routes': 'cest',
   'featurepanel.hidden_crags': 'skrytých sektorů',
   'featurepanel.error.title': 'Při zobrazení tohoto místa se něco pokazilo.',
-  'featurepanel.error.description':
-    'Zbytek mapy funguje dál. Zkus se vrátit zpět nebo otevřít jiné místo.',
+  'featurepanel.error.description': 'Zbytek mapy funguje dál. Zkus se vrátit zpět nebo otevřít jiné místo.',
   'featurepanel.error.back': 'Zpět',
   'photo_coverage.tooltip': '__withPhoto__ z __total__ cest (__percent__\u00A0%) je zakresleno na fotce',
 

--- a/src/locales/cs.js
+++ b/src/locales/cs.js
@@ -358,6 +358,10 @@ export default {
   'featurepanel.type_crag': 'Sektor',
   'featurepanel.routes': 'cest',
   'featurepanel.hidden_crags': 'skrytých sektorů',
+  'featurepanel.error.title': 'Při zobrazení tohoto místa se něco pokazilo.',
+  'featurepanel.error.description':
+    'Zbytek mapy funguje dál. Zkus se vrátit zpět nebo otevřít jiné místo.',
+  'featurepanel.error.back': 'Zpět',
   'photo_coverage.tooltip': '__withPhoto__ z __total__ cest (__percent__\u00A0%) je zakresleno na fotce',
 
   'opening_hours.open': 'Otevřeno: __todayTime__',

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -386,6 +386,10 @@ export default {
   'featurepanel.type_crag': 'Fels',
   'featurepanel.routes': 'Routen',
   'featurepanel.hidden_crags': 'ausgeblendete Felsen',
+  'featurepanel.error.title': 'Beim Anzeigen dieses Orts ist etwas schiefgelaufen.',
+  'featurepanel.error.description':
+    'Der Rest der Karte funktioniert weiterhin. Geh zurück oder öffne einen anderen Ort.',
+  'featurepanel.error.back': 'Zurück',
   'photo_coverage.tooltip': '__withPhoto__ von __total__ Routen (__percent__ %) sind auf einem Foto eingezeichnet',
   'opening_hours.all_day': '24 Stunden',
   'opening_hours.open': 'Geöffnet: __todayTime__',

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -387,8 +387,7 @@ export default {
   'featurepanel.routes': 'Routen',
   'featurepanel.hidden_crags': 'ausgeblendete Felsen',
   'featurepanel.error.title': 'Beim Anzeigen dieses Orts ist etwas schiefgelaufen.',
-  'featurepanel.error.description':
-    'Der Rest der Karte funktioniert weiterhin. Geh zurück oder öffne einen anderen Ort.',
+  'featurepanel.error.description': 'Der Rest der Karte funktioniert weiterhin. Geh zurück oder öffne einen anderen Ort.',
   'featurepanel.error.back': 'Zurück',
   'photo_coverage.tooltip': '__withPhoto__ von __total__ Routen (__percent__ %) sind auf einem Foto eingezeichnet',
   'opening_hours.all_day': '24 Stunden',

--- a/src/locales/es.js
+++ b/src/locales/es.js
@@ -387,8 +387,7 @@ export default {
   'featurepanel.routes': 'vías',
   'featurepanel.hidden_crags': 'zonas ocultas',
   'featurepanel.error.title': 'Algo salió mal al mostrar este lugar.',
-  'featurepanel.error.description':
-    'El resto del mapa sigue funcionando. Prueba a volver atrás o abrir otro lugar.',
+  'featurepanel.error.description': 'El resto del mapa sigue funcionando. Prueba a volver atrás o abrir otro lugar.',
   'featurepanel.error.back': 'Volver',
   'photo_coverage.tooltip': '__withPhoto__ de __total__ vías (__percent__ %) están dibujadas sobre una foto',
   'opening_hours.all_day': '24 horas',

--- a/src/locales/es.js
+++ b/src/locales/es.js
@@ -386,6 +386,10 @@ export default {
   'featurepanel.type_crag': 'Zona',
   'featurepanel.routes': 'vías',
   'featurepanel.hidden_crags': 'zonas ocultas',
+  'featurepanel.error.title': 'Algo salió mal al mostrar este lugar.',
+  'featurepanel.error.description':
+    'El resto del mapa sigue funcionando. Prueba a volver atrás o abrir otro lugar.',
+  'featurepanel.error.back': 'Volver',
   'photo_coverage.tooltip': '__withPhoto__ de __total__ vías (__percent__ %) están dibujadas sobre una foto',
   'opening_hours.all_day': '24 horas',
   'opening_hours.open': 'Abierto: __todayTime__',

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -389,8 +389,7 @@ export default {
   'featurepanel.routes': 'voies',
   'featurepanel.hidden_crags': 'sites masqués',
   'featurepanel.error.title': "Une erreur est survenue lors de l'affichage de ce lieu.",
-  'featurepanel.error.description':
-    "Le reste de la carte fonctionne toujours. Essayez de revenir en arrière ou d'ouvrir un autre lieu.",
+  'featurepanel.error.description': "Le reste de la carte fonctionne toujours. Essayez de revenir en arrière ou d'ouvrir un autre lieu.",
   'featurepanel.error.back': 'Retour',
   'photo_coverage.tooltip': '__withPhoto__ sur __total__ voies (__percent__ %) sont dessinées sur une photo',
   'opening_hours.all_day': '24 heures',

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -388,6 +388,10 @@ export default {
   'featurepanel.type_crag': 'Site',
   'featurepanel.routes': 'voies',
   'featurepanel.hidden_crags': 'sites masqués',
+  'featurepanel.error.title': "Une erreur est survenue lors de l'affichage de ce lieu.",
+  'featurepanel.error.description':
+    "Le reste de la carte fonctionne toujours. Essayez de revenir en arrière ou d'ouvrir un autre lieu.",
+  'featurepanel.error.back': 'Retour',
   'photo_coverage.tooltip': '__withPhoto__ sur __total__ voies (__percent__ %) sont dessinées sur une photo',
   'opening_hours.all_day': '24 heures',
   'opening_hours.open': 'Ouverture à : __todayTime__',

--- a/src/locales/it.js
+++ b/src/locales/it.js
@@ -386,8 +386,7 @@ export default {
   'featurepanel.routes': 'vie',
   'featurepanel.hidden_crags': 'falesie nascoste',
   'featurepanel.error.title': 'Qualcosa è andato storto durante la visualizzazione di questo luogo.',
-  'featurepanel.error.description':
-    'Il resto della mappa funziona ancora. Prova a tornare indietro o ad aprire un altro luogo.',
+  'featurepanel.error.description': 'Il resto della mappa funziona ancora. Prova a tornare indietro o ad aprire un altro luogo.',
   'featurepanel.error.back': 'Indietro',
   'photo_coverage.tooltip': '__withPhoto__ di __total__ vie (__percent__ %) sono disegnate su una foto',
   'opening_hours.all_day': '24 ore',

--- a/src/locales/it.js
+++ b/src/locales/it.js
@@ -385,6 +385,10 @@ export default {
   'featurepanel.type_crag': 'Falesia',
   'featurepanel.routes': 'vie',
   'featurepanel.hidden_crags': 'falesie nascoste',
+  'featurepanel.error.title': 'Qualcosa è andato storto durante la visualizzazione di questo luogo.',
+  'featurepanel.error.description':
+    'Il resto della mappa funziona ancora. Prova a tornare indietro o ad aprire un altro luogo.',
+  'featurepanel.error.back': 'Indietro',
   'photo_coverage.tooltip': '__withPhoto__ di __total__ vie (__percent__ %) sono disegnate su una foto',
   'opening_hours.all_day': '24 ore',
   'opening_hours.open': 'Apertura: __todayTime__',

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -97,8 +97,7 @@ export default {
   'featurepanel.error_network': '地物を取得できません。通信環境を確認してください。',
   'featurepanel.error_deleted': 'この地物は OpenStreetMap で削除済みとしてマークされています。',
   'featurepanel.error.title': 'この場所の表示中に問題が発生しました。',
-  'featurepanel.error.description':
-    '地図の他の部分は引き続き利用できます。前に戻るか、別の場所を開いてみてください。',
+  'featurepanel.error.description': '地図の他の部分は引き続き利用できます。前に戻るか、別の場所を開いてみてください。',
   'featurepanel.error.back': '戻る',
   'featurepanel.info_no_tags': 'この地物にはタグがありません。通常、これは親オブジェクトの形状/位置のみを保持することを意味します。',
   'featurepanel.history_button': '履歴 »',

--- a/src/locales/ja.js
+++ b/src/locales/ja.js
@@ -96,6 +96,10 @@ export default {
   'featurepanel.error_unknown': 'OpenStreetMap から地物を取得中に不明なエラーが発生しました。',
   'featurepanel.error_network': '地物を取得できません。通信環境を確認してください。',
   'featurepanel.error_deleted': 'この地物は OpenStreetMap で削除済みとしてマークされています。',
+  'featurepanel.error.title': 'この場所の表示中に問題が発生しました。',
+  'featurepanel.error.description':
+    '地図の他の部分は引き続き利用できます。前に戻るか、別の場所を開いてみてください。',
+  'featurepanel.error.back': '戻る',
   'featurepanel.info_no_tags': 'この地物にはタグがありません。通常、これは親オブジェクトの形状/位置のみを保持することを意味します。',
   'featurepanel.history_button': '履歴 »',
   'featurepanel.details_heading': '詳細',

--- a/src/locales/pl.js
+++ b/src/locales/pl.js
@@ -384,6 +384,10 @@ export default {
   'featurepanel.type_crag': 'Rejon',
   'featurepanel.routes': 'drogi',
   'featurepanel.hidden_crags': 'ukryte rejony',
+  'featurepanel.error.title': 'Coś poszło nie tak podczas wyświetlania tego miejsca.',
+  'featurepanel.error.description':
+    'Reszta mapy nadal działa. Spróbuj wrócić lub otworzyć inne miejsce.',
+  'featurepanel.error.back': 'Wstecz',
   'photo_coverage.tooltip': '__withPhoto__ z __total__ dróg (__percent__ %) jest narysowanych na zdjęciu',
   'opening_hours.all_day': '24 godziny',
   'opening_hours.open': 'Otwarte: __todayTime__',

--- a/src/locales/pl.js
+++ b/src/locales/pl.js
@@ -385,8 +385,7 @@ export default {
   'featurepanel.routes': 'drogi',
   'featurepanel.hidden_crags': 'ukryte rejony',
   'featurepanel.error.title': 'Coś poszło nie tak podczas wyświetlania tego miejsca.',
-  'featurepanel.error.description':
-    'Reszta mapy nadal działa. Spróbuj wrócić lub otworzyć inne miejsce.',
+  'featurepanel.error.description': 'Reszta mapy nadal działa. Spróbuj wrócić lub otworzyć inne miejsce.',
   'featurepanel.error.back': 'Wstecz',
   'photo_coverage.tooltip': '__withPhoto__ z __total__ dróg (__percent__ %) jest narysowanych na zdjęciu',
   'opening_hours.all_day': '24 godziny',

--- a/src/locales/uk.js
+++ b/src/locales/uk.js
@@ -385,6 +385,10 @@ export default {
   'featurepanel.type_crag': 'Скеля',
   'featurepanel.routes': 'маршрути',
   'featurepanel.hidden_crags': 'приховані скелі',
+  'featurepanel.error.title': 'Під час показу цього місця сталася помилка.',
+  'featurepanel.error.description':
+    'Решта карти працює. Спробуйте повернутися назад або відкрити інше місце.',
+  'featurepanel.error.back': 'Назад',
   'photo_coverage.tooltip': '__withPhoto__ із __total__ маршрутів (__percent__ %) намальовано на фото',
   'opening_hours.all_day': '24 години',
   'opening_hours.open': 'Відкрито: __todayTime__',

--- a/src/locales/uk.js
+++ b/src/locales/uk.js
@@ -386,8 +386,7 @@ export default {
   'featurepanel.routes': 'маршрути',
   'featurepanel.hidden_crags': 'приховані скелі',
   'featurepanel.error.title': 'Під час показу цього місця сталася помилка.',
-  'featurepanel.error.description':
-    'Решта карти працює. Спробуйте повернутися назад або відкрити інше місце.',
+  'featurepanel.error.description': 'Решта карти працює. Спробуйте повернутися назад або відкрити інше місце.',
   'featurepanel.error.back': 'Назад',
   'photo_coverage.tooltip': '__withPhoto__ із __total__ маршрутів (__percent__ %) намальовано на фото',
   'opening_hours.all_day': '24 години',

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -403,6 +403,10 @@ export default {
   'featurepanel.type_crag': 'Crag',
   'featurepanel.routes': 'routes',
   'featurepanel.hidden_crags': 'hidden crags',
+  'featurepanel.error.title': 'Something went wrong while showing this place.',
+  'featurepanel.error.description':
+    'The rest of the map still works. Try going back or opening another place.',
+  'featurepanel.error.back': 'Go back',
   'photo_coverage.tooltip': '__withPhoto__ of __total__ routes (__percent__\u00A0%) are drawn on a photo',
 
   'opening_hours.all_day': '24 hours',

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -404,8 +404,7 @@ export default {
   'featurepanel.routes': 'routes',
   'featurepanel.hidden_crags': 'hidden crags',
   'featurepanel.error.title': 'Something went wrong while showing this place.',
-  'featurepanel.error.description':
-    'The rest of the map still works. Try going back or opening another place.',
+  'featurepanel.error.description': 'The rest of the map still works. Try going back or opening another place.',
   'featurepanel.error.back': 'Go back',
   'photo_coverage.tooltip': '__withPhoto__ of __total__ routes (__percent__\u00A0%) are drawn on a photo',
 

--- a/src/locales/zh-CN.js
+++ b/src/locales/zh-CN.js
@@ -184,6 +184,9 @@ export default {
   'featurepanel.sectors': '岩场',
   'featurepanel.routes': '路线',
   'featurepanel.hidden_crags': '隐藏岩场',
+  'featurepanel.error.title': '显示此地点时出现问题。',
+  'featurepanel.error.description': '地图的其余部分仍可正常使用。请尝试返回或打开其他地点。',
+  'featurepanel.error.back': '返回',
 
   'opening_hours.all_day': '24 小时',
   'opening_hours.open': '营业中：__todayTime__',

--- a/src/locales/zh-HK.js
+++ b/src/locales/zh-HK.js
@@ -184,6 +184,9 @@ export default {
   'featurepanel.sectors': '岩場',
   'featurepanel.routes': '路線',
   'featurepanel.hidden_crags': '隱藏岩場',
+  'featurepanel.error.title': '顯示此地點時發生問題。',
+  'featurepanel.error.description': '地圖其他部分仍可正常運作。請嘗試返回或開啟其他地點。',
+  'featurepanel.error.back': '返回',
 
   'opening_hours.all_day': '24 小時',
   'opening_hours.open': '營業中：__todayTime__',

--- a/src/locales/zh-TW.js
+++ b/src/locales/zh-TW.js
@@ -183,6 +183,9 @@ export default {
   'featurepanel.sectors': '岩場',
   'featurepanel.routes': '路線',
   'featurepanel.hidden_crags': '隱藏岩場',
+  'featurepanel.error.title': '顯示此地點時發生問題。',
+  'featurepanel.error.description': '地圖的其他部分仍可正常使用。請嘗試返回或開啟其他地點。',
+  'featurepanel.error.back': '返回',
 
   'opening_hours.all_day': '24 小時',
   'opening_hours.open': '營業中：__todayTime__',


### PR DESCRIPTION
Isolates render crashes with local error boundary

eg. it would have catched the error in the v1 of fetch Feature from DB (#111).

--
Claude-Session: https://claude.ai/code/session_01WLFMNjSA3ZQYqRXbXQsc8y
