### PR TITLE
ci: generate sourceMaps for VPS deploy

### DIFF
--- a/.github/workflows/vps-deploy.yml
+++ b/.github/workflows/vps-deploy.yml
@@ -44,6 +44,7 @@ jobs:
           echo "VERCEL_GIT_COMMIT_SHA=$(git rev-parse HEAD)" >> .env
           echo "VERCEL_GIT_COMMIT_MESSAGE=$(git log -1 --pretty=%B)" >> .env
           echo "NEXT_PUBLIC_ENABLE_CLIMBING_TILES=true" >> .env
+          echo "VPS_DEPLOY=true" >> .env
 
           NEXTJS_OUTPUT=standalone yarn build
           mv public .next/standalone

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,6 +6,7 @@ const osmappVersion = process.env.npm_package_version;
 const commitHash = (process.env.VERCEL_GIT_COMMIT_SHA || '').substring(0, 7);
 const commitMessage = process.env.VERCEL_GIT_COMMIT_MESSAGE || 'dev';
 const sentryRelease = `${osmappVersion}-${commitHash}-${commitMessage.substring(0, 20)}`;
+const isVpsDeploy = !!process.env.VPS_DEPLOY; // set only in vps-deploy.yml, so PR/preview builds stay fast
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -45,8 +46,8 @@ export default withSentryConfig(nextConfig, {
   org: 'osmapp', // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
   project: 'osmapp',
   silent: !process.env.CI,
-  widenClientFileUpload: false, // smaller set of source maps -> faster builds, smaller Sentry storage
-  reactComponentAnnotation: { enabled: false }, // component-name annotations bloat runtime bundle
+  widenClientFileUpload: isVpsDeploy, // full source maps only for the production VPS build
+  reactComponentAnnotation: { enabled: isVpsDeploy }, // component-name annotations bloat runtime bundle, keep off elsewhere
   // tunnelRoute: '/monitoring',
   hideSourceMaps: false,
   disableLogger: true, // Automatically tree-shake Sentry logger statements to reduce bundle size


### PR DESCRIPTION
### Description

Conditionally enable Sentry source map uploads and React component annotations only for VPS production builds, while keeping them disabled for faster PR and preview builds.

This change introduces a `VPS_DEPLOY` environment variable that is set only during VPS deployments. When disabled (default for PR/preview builds):
- `widenClientFileUpload` is set to `false` to reduce source map uploads and Sentry storage usage
- `reactComponentAnnotation` is disabled to prevent component-name annotations from bloating the runtime bundle

When enabled (VPS production builds only):
- Full source maps are uploaded for better production debugging
- React component annotations are enabled for enhanced error tracking

This optimization reduces build times and bundle sizes for non-production deployments while maintaining full observability in production.

### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)

https://claude.ai/code/session_018fAqnZdzSPqa64REgVVtnU