### PR TITLE
tagging: fix getFieldTranslation crash on undefined lang

### DIFF
--- a/src/services/tagging/__tests__/translations.test.ts
+++ b/src/services/tagging/__tests__/translations.test.ts
@@ -1,5 +1,7 @@
 import { intl } from '../../intl';
+import { Field } from '../types/Fields';
 import {
+  getFieldTranslation,
   getPresetTermsTranslation,
   mockSchemaTranslations,
 } from '../translations';
@@ -35,5 +37,44 @@ describe('getPresetTermsTranslation', () => {
     mockSchemaTranslations({ en: { presets: { presets: {} } } });
 
     expect(getPresetTermsTranslation('does-not-exist')).toEqual([]);
+  });
+});
+
+describe('getFieldTranslation', () => {
+  // Regression: `intl.lang` is a module-level singleton shared by every
+  // concurrent SSR request. A request for a locale whose translations
+  // haven't been fetched yet (or that races another request's fetch) used to
+  // crash the whole page with "Cannot read properties of undefined (reading
+  // 'presets')" instead of just falling back to the untranslated label.
+  it('returns undefined instead of throwing when the current lang has no translations loaded', () => {
+    mockSchemaTranslations({ en: { presets: { fields: {} } } });
+    intl.lang = 'de'; // not present in the mocked translations
+
+    const field = { fieldKey: 'surface' } as Field;
+
+    expect(() => getFieldTranslation(field)).not.toThrow();
+    expect(getFieldTranslation(field)).toBeUndefined();
+
+    intl.lang = 'en';
+  });
+
+  it('resolves a field by fieldKey', () => {
+    mockSchemaTranslations({
+      en: { presets: { fields: { surface: { label: 'Surface' } } } },
+    });
+
+    const field = { fieldKey: 'surface' } as Field;
+
+    expect(getFieldTranslation(field)).toEqual({ label: 'Surface' });
+  });
+
+  it('resolves a {template} label by looking up the referenced field', () => {
+    mockSchemaTranslations({
+      en: { presets: { fields: { surface: { label: 'Surface' } } } },
+    });
+
+    const field = { fieldKey: 'crag/surface', label: '{surface}' } as Field;
+
+    expect(getFieldTranslation(field)).toEqual({ label: 'Surface' });
   });
 });

--- a/src/services/tagging/translations.ts
+++ b/src/services/tagging/translations.ts
@@ -60,14 +60,12 @@ export const getPresetTermsTranslation = (key: string): string[] => {
 export const getAllTranslations = () => translations?.[intl.lang];
 
 export const getFieldTranslation = (field: Field): FieldTranslation => {
-  if (!translations) return undefined;
-
   if (field.label?.match(/^{.*}$/)) {
     const resolved = field.label.substring(1, field.label.length - 1);
-    return translations[intl.lang].presets.fields[resolved];
+    return translations?.[intl.lang]?.presets?.fields?.[resolved];
   }
 
   // The id 169522276 is different for each intl.language :(
   // https://www.transifex.com/openstreetmap/id-editor/translate/#cs/presets/169522276?q=key%3Apresets.fields.XXX
-  return translations[intl.lang].presets.fields[field.fieldKey];
+  return translations?.[intl.lang]?.presets?.fields?.[field.fieldKey];
 };


### PR DESCRIPTION
### Description

Sentry: `TypeError: Cannot read properties of undefined (reading 'presets')`, ~2400 events/7d, mostly on `openclimbing.org/relation/*` (climbing area/crag pages), culprit `getInitialProps (/_app)`.

`getFieldTranslation()` guarded `translations` (always truthy, `{}` at minimum) but not `translations[intl.lang]`. `intl.lang` is a module-level singleton shared by every concurrent SSR request in the same Node process - a request for a locale whose translations haven't loaded yet (or one that races another request's `fetchSchemaTranslations()` call) hit `translations[intl.lang].presets` while `translations[intl.lang]` was still `undefined`, crashing the whole page render instead of just falling back to the untranslated label (both call sites already handle `undefined` via `?.`/spread).

- Switched both property accesses in `getFieldTranslation()` to optional chaining, matching the pattern already used by `getPresetTranslation`/`getPresetTermsTranslation` in the same file.
- Added a regression test that reproduces the crash (fails without the fix) plus two happy-path cases.

https://claude.ai/code/session_01YChsE67uVMznndDeUHwbwA


---
_Generated by [Claude Code](https://claude.ai/code/session_01YChsE67uVMznndDeUHwbwA)_