### PR TITLE
Map: init with emptyStyle instead of basicStyle to fix aborted requests

### DIFF
--- a/src/components/Map/behaviour/useInitMap.tsx
+++ b/src/components/Map/behaviour/useInitMap.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import maplibregl from 'maplibre-gl';
-import { basicStyle } from '../styles/basicStyle';
+import { emptyStyle } from '../styles/emptyStyle';
 import { setGlobalMap } from '../../../services/mapStorage';
 import { COMPASS_TOOLTIP } from '../useAddTopRightControls';
 
@@ -52,7 +52,9 @@ export const useInitMap = () => {
 
     const map = new maplibregl.Map({
       container: containerRef.current,
-      style: basicStyle,
+      // real style is set right after by useUpdateStyle() - starting with
+      // basicStyle here made the map fetch it, then immediately abort it
+      style: emptyStyle,
       attributionControl: false,
       refreshExpiredTiles: false,
       locale: {


### PR DESCRIPTION
useUpdateStyle() replaces the style right after mount anyway, so initializing with basicStyle just kicked off real tile/sprite fetches that got immediately aborted (Sentry: AJAXError signal is aborted without reason, 70k+ events).
