### PR TITLE
search: add separators

### DIFF
--- a/src/components/SearchBox/AutocompleteInput.tsx
+++ b/src/components/SearchBox/AutocompleteInput.tsx
@@ -79,7 +79,9 @@ export const AutocompleteInput: React.FC<AutocompleteInputProps> = ({
       renderOption={renderOptionFactory(inputValue)}
       renderInput={renderInputFactory(setInputValue, autocompleteRef)}
       filterOptions={(option) => option}
-      getOptionDisabled={(option) => option.type === 'loader'}
+      getOptionDisabled={(option) =>
+        option.type === 'loader' || option.type === 'separator'
+      }
       getOptionKey={(option) => JSON.stringify(option)}
     />
   );

--- a/src/components/SearchBox/renderOptionFactory.tsx
+++ b/src/components/SearchBox/renderOptionFactory.tsx
@@ -8,6 +8,7 @@ import { OsmRow } from './options/osm';
 import { CoordsRow } from './options/coords';
 import { ClimbingRow } from './options/climbing';
 import { TilesRow } from './options/tiles';
+import { SeparatorRow } from './separators';
 
 type Props = {
   option: Option;
@@ -32,14 +33,30 @@ const Row = ({ option, inputValue }: Props) => {
       return <TilesRow option={option} />;
     case 'loader':
       return <LoaderRow />;
+    case 'separator':
+      return <SeparatorRow />;
   }
 };
 
 export const renderOptionFactory = (inputValue: string) => {
-  const renderOptionFn = ({ key, ...props }, option: Option) => (
-    <li key={key} {...props}>
-      <Row option={option} inputValue={inputValue} />
-    </li>
-  );
+  const renderOptionFn = ({ key, ...props }, option: Option) => {
+    if (option.type === 'separator') {
+      return (
+        <li
+          key={key}
+          {...props} // eslint-disable-line react/jsx-props-no-spreading
+          style={{ padding: 0, minHeight: 0, pointerEvents: 'none' }}
+        >
+          <SeparatorRow />
+        </li>
+      );
+    }
+
+    return (
+      <li key={key} {...props}>
+        <Row option={option} inputValue={inputValue} />
+      </li>
+    );
+  };
   return renderOptionFn;
 };

--- a/src/components/SearchBox/separators.tsx
+++ b/src/components/SearchBox/separators.tsx
@@ -1,0 +1,41 @@
+import { Divider } from '@mui/material';
+import styled from '@emotion/styled';
+import React from 'react';
+import { Option } from './types';
+
+// Groups that can appear in the results, in the order they're built in
+// useGetOptions. A separator is inserted wherever two neighbouring options
+// belong to a different group.
+const getSection = (option: Option): string => {
+  if (option.type === 'climbing') {
+    const { type } = option.climbing;
+    return type === 'route' || type === 'route_top'
+      ? 'climbing-route'
+      : 'climbing-group';
+  }
+  return option.type;
+};
+
+export const withSeparators = (options: Option[]): Option[] => {
+  const result: Option[] = [];
+  let prevSection: string | undefined;
+
+  options.forEach((option) => {
+    const section = getSection(option);
+    if (prevSection !== undefined && section !== prevSection) {
+      result.push({ type: 'separator', separator: { section } });
+    }
+    result.push(option);
+    prevSection = section;
+  });
+
+  return result;
+};
+
+const StyledDivider = styled(Divider)`
+  width: 100%;
+  margin: 2px 0;
+  border-color: ${({ theme }) => theme.palette.divider};
+`;
+
+export const SeparatorRow = () => <StyledDivider />;

--- a/src/components/SearchBox/separators.tsx
+++ b/src/components/SearchBox/separators.tsx
@@ -34,8 +34,11 @@ export const withSeparators = (options: Option[]): Option[] => {
 
 const StyledDivider = styled(Divider)`
   width: 100%;
-  margin: 2px 0;
-  border-color: ${({ theme }) => theme.palette.divider};
+  margin: 4px 0;
+  border-color: ${({ theme }) =>
+    theme.palette.mode === 'dark'
+      ? 'rgba(255, 255, 255, 0.12)'
+      : 'rgba(0, 0, 0, 0.12)'};
 `;
 
 export const SeparatorRow = () => <StyledDivider />;

--- a/src/components/SearchBox/types.ts
+++ b/src/components/SearchBox/types.ts
@@ -71,6 +71,8 @@ export type PresetOption = GenericOption<
 
 type LoaderOption = GenericOption<'loader', null>;
 
+export type SeparatorOption = GenericOption<'separator', { section: string }>;
+
 export type CoordsOption = GenericOption<
   'coords',
   { center: LonLat; label: string; sublabel: string }
@@ -100,4 +102,5 @@ export type Option =
   | GeocoderOption
   | ClimbingOption
   | OsmOption
-  | TilesOption;
+  | TilesOption
+  | SeparatorOption;

--- a/src/components/SearchBox/useGetOptions.tsx
+++ b/src/components/SearchBox/useGetOptions.tsx
@@ -18,6 +18,7 @@ import {
   CLIMBING_SEARCH_ABORTABLE_QUEUE,
   fetchClimbingSearchOptions,
 } from './options/climbing';
+import { withSeparators } from './separators';
 
 const getMatchedOptions = (inputValue: string) => {
   if (inputValue === '') {
@@ -100,12 +101,14 @@ export const useGetOptions = (
           return; // This blocks rendering of old result, when user already changed input
         }
 
-        setOptions([
-          ...before,
-          ...climbingOptions,
-          ...geocoderOptions,
-          ...restPresets,
-        ]);
+        setOptions(
+          withSeparators([
+            ...before,
+            ...climbingOptions,
+            ...geocoderOptions,
+            ...restPresets,
+          ]),
+        );
       } catch (e) {
         if (e instanceof GeocoderDebounced || e instanceof GeocoderAborted) {
           return;


### PR DESCRIPTION
### Description

Adds a light horizontal divider between each group of search results (presets → climbing groups → climbing routes → ordinary results → presets).



<img width="328" alt="image" src="https://github.com/user-attachments/assets/5e84eaf5-b9b4-468a-b42b-b213061c6164" />


### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)

https://claude.ai/code/session_012D9WGDRFiB98bBhsicECUM

---
_Generated by [Claude Code](https://claude.ai/code/session_012D9WGDRFiB98bBhsicECUM)_