### PR TITLE
search: fix flex-shrink

### DIFF
--- a/src/components/SearchBox/utils.tsx
+++ b/src/components/SearchBox/utils.tsx
@@ -16,6 +16,7 @@ import { SEARCH_THRESHOLD } from './consts';
 
 export const IconPart = styled.div`
   width: 50px;
+  flex-shrink: 0;
   text-align: center;
   padding-right: 10px;
   font-size: 10px;


### PR DESCRIPTION
### Description

Search result rows were misaligned because the icon column could shrink below its fixed 50px width depending on the icon type, shifting the title text left on some rows.

### Checklist

- [x] mobile / desktop

https://claude.ai/code/session_013yYrFnXJNZt5Y94TYrYbVP

---
_Generated by [Claude Code](https://claude.ai/code/session_013yYrFnXJNZt5Y94TYrYbVP)_