### PR TITLE
getCenter: compute feature bbox on FE

### DIFF
--- a/src/services/__tests__/getCenter.test.ts
+++ b/src/services/__tests__/getCenter.test.ts
@@ -1,0 +1,54 @@
+import { getFeatureBbox } from '../getCenter';
+import { Feature } from '../types';
+
+const feature = (props: Partial<Feature>): Feature =>
+  ({
+    type: 'Feature',
+    osmMeta: { type: 'node', id: 1 },
+    tags: {},
+    properties: { class: '', subclass: '' },
+    ...props,
+  }) as Feature;
+
+describe('getFeatureBbox', () => {
+  it('returns the bbox from the API untouched', () => {
+    const crag = feature({
+      center: [14, 50],
+      bbox: [1, 2, 3, 4],
+      memberFeatures: [feature({ center: [20, 60] })],
+    });
+
+    expect(getFeatureBbox(crag)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('measures geometry, center and the memberFeatures subtree', () => {
+    const crag = feature({
+      center: [14, 50],
+      memberFeatures: [
+        feature({
+          center: [14.02, 50.02],
+          geometry: {
+            type: 'LineString',
+            coordinates: [
+              [14.01, 50.01],
+              [14.03, 49.99],
+            ],
+          },
+        }),
+        feature({ memberFeatures: [feature({ center: [13.99, 50.05] })] }),
+      ],
+    });
+
+    expect(getFeatureBbox(crag)).toEqual([13.99, 49.99, 14.03, 50.05]);
+  });
+
+  it('degenerates to a point for a single node', () => {
+    expect(getFeatureBbox(feature({ center: [14.5, 50.5] }))).toEqual([
+      14.5, 50.5, 14.5, 50.5,
+    ]);
+  });
+
+  it('returns undefined when there is nothing to measure', () => {
+    expect(getFeatureBbox(feature({}))).toBeUndefined();
+  });
+});

--- a/src/services/getCenter.ts
+++ b/src/services/getCenter.ts
@@ -1,4 +1,6 @@
+import { BBox } from 'geojson';
 import {
+  Feature,
   FeatureGeometry,
   GeometryCollection,
   isGeometryCollection,
@@ -41,18 +43,51 @@ const getCenterOfBbox = (points: LonLat[]): LonLat | undefined => {
 };
 
 const getPointsRecursive = (geometry: GeometryCollection): LonLat[] =>
-  geometry.geometries.flatMap((subGeometry) => {
-    if (isGeometryCollection(subGeometry)) {
-      return getPointsRecursive(subGeometry);
-    }
-    if (isLineString(subGeometry)) {
-      return subGeometry.coordinates;
-    }
-    if (isPoint(subGeometry)) {
-      return [subGeometry.coordinates];
-    }
-    return [];
-  });
+  geometry.geometries.flatMap((subGeometry) => getPoints(subGeometry));
+
+const getPoints = (geometry: FeatureGeometry): LonLat[] => {
+  if (isPoint(geometry)) {
+    return [geometry.coordinates];
+  }
+  if (isLineString(geometry)) {
+    return geometry.coordinates;
+  }
+  if (isPolygon(geometry)) {
+    return geometry.coordinates.flat() as LonLat[];
+  }
+  if (isGeometryCollection(geometry)) {
+    return getPointsRecursive(geometry);
+  }
+  return [];
+};
+
+const collectPoints = (feature: Feature, out: LonLat[]) => {
+  out.push(...getPoints(feature.geometry));
+  if (feature.center) {
+    out.push(feature.center);
+  }
+  for (const member of feature.memberFeatures ?? []) {
+    collectPoints(member, out);
+  }
+};
+
+// Climbing features get `bbox` from the climbing-tiles API, everything else
+// (OSM/Overpass) has to be measured here - from the geometry, the centers and
+// the whole memberFeatures subtree.
+export const getFeatureBbox = (feature: Feature): BBox | undefined => {
+  if (feature.bbox) {
+    return feature.bbox;
+  }
+
+  const points: LonLat[] = [];
+  collectPoints(feature, points);
+  if (!points.length) {
+    return undefined;
+  }
+
+  const { w, s, e, n } = getBbox(points);
+  return [w, s, e, n];
+};
 
 export const getCenter = (geometry: FeatureGeometry): LonLat => {
   if (isPoint(geometry)) {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1,6 +1,6 @@
 import type Vocabulary from '../locales/vocabulary';
 import type { getSchemaForFeature } from './tagging/idTaggingScheme';
-import type { Polygon } from 'geojson';
+import type { BBox, Polygon } from 'geojson';
 
 export type OsmType = 'node' | 'way' | 'relation';
 export type OsmId = {
@@ -113,6 +113,7 @@ export type Feature = {
   imageDefs?: ImageDef[];
   properties: FeatureProperties;
   center: LonLat;
+  bbox?: BBox; // [w, s, e, n] - only from climbing-tiles, see getFeatureBbox()
   countryCode?: string; // ISO3166-1 code lowercase, undefined = no country
   roundedCenter?: LonLatRounded;
   error?: 'network' | 'unknown' | '404' | '500'; // etc.


### PR DESCRIPTION
### Description

Features from OSM/Overpass have no `bbox` from the API, so `getFeatureBbox()` measures it on the frontend from the geometry, centers and the whole `memberFeatures` subtree (climbing-tiles features keep the `bbox` computed on the server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4UtHY3iqBjpDRendJvqqt


---
_Generated by [Claude Code](https://claude.ai/code/session_01D4UtHY3iqBjpDRendJvqqt)_