### PR TITLE
fix: enable double click in climbing dialog

### DIFF
--- a/src/components/FeaturePanel/Climbing/ClimbingCragDialogHeader.tsx
+++ b/src/components/FeaturePanel/Climbing/ClimbingCragDialogHeader.tsx
@@ -3,11 +3,17 @@ import AddPhotoAlternateIcon from '@mui/icons-material/AddPhotoAlternate';
 import CloseIcon from '@mui/icons-material/Close';
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
 import TuneIcon from '@mui/icons-material/Tune';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import MapIcon from '@mui/icons-material/Map';
+import FormatListNumberedIcon from '@mui/icons-material/FormatListNumbered';
 import {
   AppBar,
   Box,
   Button,
   IconButton,
+  ListItemIcon,
+  ListItemText,
+  MenuItem,
   Stack,
   Toolbar,
   Tooltip,
@@ -28,6 +34,7 @@ import {
   getWikimediaCommonsKey,
 } from './utils/photo';
 import { usePhotoChange } from './utils/usePhotoChange';
+import { useMoreMenu } from './useMoreMenu';
 
 // Heavy client-only export dialog; loaded lazily (only when the user opens the
 // PDF export) so it stays out of the shared bundle.
@@ -222,9 +229,11 @@ export const ClimbingCragDialogHeader = ({
   const [isUserSettingsOpened, setIsUserSettingsOpened] =
     useState<boolean>(false);
   const [isPdfExportOpen, setIsPdfExportOpen] = useState<boolean>(false);
-  const { photoPath, photoPaths, isEditMode } = useClimbingContext();
+  const { photoPath, photoPaths, isEditMode, isMapVisible, setIsMapVisible } =
+    useClimbingContext();
   const { openWithTag } = useEditDialogContext();
   const isMobileMode = useMobileMode();
+  const { handleClickMore, handleCloseMore, MoreMenu } = useMoreMenu();
   // On mobile the bottom DialogActions bar is hidden, so Save/Cancel live in
   // the header instead of the PDF/settings/close icons while editing.
   const showMobileEditActions = isMobileMode && isEditMode;
@@ -293,8 +302,89 @@ export const ClimbingCragDialogHeader = ({
               {t('editdialog.save_button_edit')}
             </Button>
           </Stack>
+        ) : isMobileMode ? (
+          <>
+            <IconButton
+              color="primary"
+              onClick={handleClickMore}
+              aria-label={t('climbing.display_settings')}
+            >
+              <MoreVertIcon fontSize="small" />
+            </IconButton>
+            <Tooltip title="Close crag detail">
+              <IconButton color="primary" edge="end" onClick={onClose}>
+                <CloseIcon fontSize="small" />
+              </IconButton>
+            </Tooltip>
+            <MoreMenu>
+              <MenuItem
+                onClick={(e) => {
+                  handleCloseMore(e);
+                  setIsPdfExportOpen(true);
+                }}
+              >
+                <ListItemIcon>
+                  <PictureAsPdfIcon fontSize="small" />
+                </ListItemIcon>
+                <ListItemText>
+                  {t('climbingpanel.pdf_export_button')}
+                </ListItemText>
+              </MenuItem>
+              <MenuItem
+                onClick={(e) => {
+                  handleCloseMore(e);
+                  setIsUserSettingsOpened(true);
+                }}
+              >
+                <ListItemIcon>
+                  <TuneIcon fontSize="small" />
+                </ListItemIcon>
+                <ListItemText>{t('climbing.display_settings')}</ListItemText>
+              </MenuItem>
+              <MenuItem
+                onClick={(e) => {
+                  handleCloseMore(e);
+                  setIsMapVisible(!isMapVisible);
+                }}
+              >
+                <ListItemIcon>
+                  {isMapVisible ? (
+                    <FormatListNumberedIcon fontSize="small" />
+                  ) : (
+                    <MapIcon fontSize="small" />
+                  )}
+                </ListItemIcon>
+                <ListItemText>
+                  {isMapVisible
+                    ? t('climbing_view.show_route_list')
+                    : t('climbing_view.show_map')}
+                </ListItemText>
+              </MenuItem>
+            </MoreMenu>
+          </>
         ) : (
           <>
+            <Box mr={1}>
+              <Tooltip
+                title={
+                  isMapVisible
+                    ? t('climbing_view.show_route_list')
+                    : t('climbing_view.show_map')
+                }
+              >
+                <IconButton
+                  color="primary"
+                  edge="end"
+                  onClick={() => setIsMapVisible(!isMapVisible)}
+                >
+                  {isMapVisible ? (
+                    <FormatListNumberedIcon fontSize="small" />
+                  ) : (
+                    <MapIcon fontSize="small" />
+                  )}
+                </IconButton>
+              </Tooltip>
+            </Box>
             <Box mr={1}>
               <Tooltip title={t('climbingpanel.pdf_export_button')}>
                 <IconButton

--- a/src/components/FeaturePanel/Climbing/ClimbingView.tsx
+++ b/src/components/FeaturePanel/Climbing/ClimbingView.tsx
@@ -4,8 +4,6 @@ import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import EditIcon from '@mui/icons-material/Edit';
-import FormatListNumberedIcon from '@mui/icons-material/FormatListNumbered';
-import MapIcon from '@mui/icons-material/Map';
 import { CircularProgress, Fab, IconButton, Tooltip } from '@mui/material';
 import { useEffect, useRef, useState } from 'react';
 import SplitPane from 'react-split-pane';
@@ -208,25 +206,6 @@ const getWindowDimensions = () => {
   };
 };
 
-const FabMapSwitcher = ({ isMapVisible, setIsMapVisible }) => (
-  <FabContainer>
-    <Tooltip
-      title={`Show ${isMapVisible ? 'route list' : 'map'}`}
-      enterDelay={1500}
-      arrow
-    >
-      <Fab
-        size="small"
-        color="secondary"
-        aria-label="add"
-        onClick={() => setIsMapVisible(!isMapVisible)}
-      >
-        {isMapVisible ? <FormatListNumberedIcon /> : <MapIcon />}
-      </Fab>
-    </Tooltip>
-  </FabContainer>
-);
-
 export const ClimbingView = () => {
   const {
     imageSize,
@@ -245,6 +224,8 @@ export const ClimbingView = () => {
     setRouteSelectedIndex,
     setIsEditMode,
     isRoutesLayerVisible,
+    isMapVisible,
+    setIsMapVisible,
   } = useClimbingContext();
   const { feature } = useFeatureContext();
   const replacePhotoIfNeeded = useReplacePhotoIfNeeded();
@@ -412,7 +393,6 @@ export const ClimbingView = () => {
     splitPaneSize === viewportSize.height - editorPosition.y;
 
   const [isPhotoLoading, setIsPhotoLoading] = useState(false);
-  const [isMapVisible, setIsMapVisible] = useState(false);
 
   const isResolutionLoaded =
     loadedPhotos?.[photoPath]?.[photoResolution] || false;
@@ -595,10 +575,6 @@ export const ClimbingView = () => {
           </BackgroundContainer>
 
           <BottomContainer ref={pane2Ref}>
-            <FabMapSwitcher
-              isMapVisible={isMapVisible}
-              setIsMapVisible={setIsMapVisible}
-            />
             <BottomPanel onScroll={handleOnScroll}>
               <ClimbingViewContent
                 isMapVisible={isMapVisible}
@@ -608,16 +584,10 @@ export const ClimbingView = () => {
           </BottomContainer>
         </SplitPane>
       ) : (
-        <>
-          <FabMapSwitcher
-            isMapVisible={isMapVisible}
-            setIsMapVisible={setIsMapVisible}
-          />
-          <ClimbingViewContent
-            isMapVisible={isMapVisible}
-            setIsMapVisible={setIsMapVisible}
-          />
-        </>
+        <ClimbingViewContent
+          isMapVisible={isMapVisible}
+          setIsMapVisible={setIsMapVisible}
+        />
       )}
     </Container>
   );

--- a/src/components/FeaturePanel/Climbing/Editor/useRoutesLayerSvgHandlers.ts
+++ b/src/components/FeaturePanel/Climbing/Editor/useRoutesLayerSvgHandlers.ts
@@ -11,6 +11,12 @@ import { useBackgroundTap } from './useBackgroundTap';
 // slightly and the drag marker would then suppress the point menu on release.
 const DRAG_START_THRESHOLD_PX = 5;
 
+// Window in which a second background tap counts as a double-tap (zoom gesture)
+// rather than a deliberate deselect. Long enough to cover a mouse double-click
+// and a finger double-tap, short enough that a single tap's deselect still
+// feels immediate.
+const DOUBLE_TAP_MS = 300;
+
 export const useRoutesLayerSvgHandlers = () => {
   const {
     machine,
@@ -52,6 +58,22 @@ export const useRoutesLayerSvgHandlers = () => {
   // Where the current gesture's first pointer landed — the reference for the
   // drag-start threshold.
   const gestureStartRef = useRef<{ x: number; y: number } | null>(null);
+
+  // A double-tap / double-click on the empty background zooms the photo (the
+  // pan/zoom wrapper handles it). Its first tap must not deselect the current
+  // route, so in view mode the background-tap deselect is deferred by one
+  // double-tap window and skipped when a second tap arrives.
+  const lastBackgroundTapRef = useRef(0);
+  const pendingDeselectRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const routeSelectedIndexRef = useRef(routeSelectedIndex);
+  routeSelectedIndexRef.current = routeSelectedIndex;
+
+  useEffect(
+    () => () => {
+      if (pendingDeselectRef.current) clearTimeout(pendingDeselectRef.current);
+    },
+    [],
+  );
 
   // Authoritative cleanup at the window level. During a pinch the fingers often
   // lift outside the SVG (or after the transform re-renders), so the SVG's own
@@ -125,7 +147,35 @@ export const useRoutesLayerSvgHandlers = () => {
         return;
       }
 
-      machine.execute('cancelRouteSelection');
+      // In edit mode (no double-tap zoom) or with nothing selected, deselect
+      // right away — there's no selection worth protecting from a zoom gesture.
+      if (isEditMode || routeSelectedIndex === null) {
+        machine.execute('cancelRouteSelection');
+        return;
+      }
+
+      if (pendingDeselectRef.current) {
+        clearTimeout(pendingDeselectRef.current);
+        pendingDeselectRef.current = null;
+      }
+
+      const now = Date.now();
+      if (now - lastBackgroundTapRef.current < DOUBLE_TAP_MS) {
+        // Second tap of a double-tap: this is a zoom gesture, keep the route.
+        lastBackgroundTapRef.current = 0;
+        return;
+      }
+      lastBackgroundTapRef.current = now;
+
+      // Defer the deselect: cancel it if a double-tap follows, and skip it if the
+      // user selected a different route in the meantime.
+      const indexAtSchedule = routeSelectedIndex;
+      pendingDeselectRef.current = setTimeout(() => {
+        pendingDeselectRef.current = null;
+        if (routeSelectedIndexRef.current === indexAtSchedule) {
+          machine.execute('cancelRouteSelection');
+        }
+      }, DOUBLE_TAP_MS);
     },
     [
       addProtectionPoint,
@@ -136,6 +186,7 @@ export const useRoutesLayerSvgHandlers = () => {
       photoZoom,
       svgRef,
       isZoomingRef,
+      routeSelectedIndex,
     ],
   );
 

--- a/src/components/FeaturePanel/Climbing/TransformWrapper.tsx
+++ b/src/components/FeaturePanel/Climbing/TransformWrapper.tsx
@@ -1,11 +1,11 @@
 import { useRef } from 'react';
 import { TransformWrapper as Wrapper } from 'react-zoom-pan-pinch';
 import { useClimbingContext } from './contexts/ClimbingContext';
-import { ZoomState } from './types';
 import {
   PANNING_EXCLUDED_CLASS,
   usePreventTouchDefaultOnDragHandles,
 } from './Editor/utils';
+import { ZoomState } from './types';
 import { useCropAnchor } from './useCropAnchor';
 
 const MAX_SCALE = 10;
@@ -31,6 +31,7 @@ export const TransformWrapper = ({ children }) => {
     isPanningDisabled,
     isAddingPointBlockedRef,
     isZoomingRef,
+    isEditMode,
   } = useClimbingContext();
 
   const panStartRef = useRef<{ x: number; y: number; time: number } | null>(
@@ -134,14 +135,17 @@ export const TransformWrapper = ({ children }) => {
 
   return (
     <Wrapper
-      // Disabled everywhere — in edit mode the double-tap would conflict
-      // with point-add gestures, and in view mode it triggers an unwanted
-      // zoom on the second tap of any double-tap-to-select recovery.
+      // Double-click / double-tap zooms the photo, but only in view mode. In
+      // edit mode it would clash with the drawing gestures (a tap adds a route
+      // point, a double-click on the last point finishes the route), so it stays
+      // off there. `excluded` also skips double-clicks that land directly on a
+      // route point / drag handle so those never trigger a zoom.
       doubleClick={{
-        disabled: true,
+        disabled: isEditMode,
         mode: 'toggle',
-        step: 1,
+        step: 1.2,
         animationTime: 150,
+        excluded: [PANNING_EXCLUDED_CLASS],
       }}
       onWheelStart={stopPointerEvents}
       onWheelStop={handleWheelStop}

--- a/src/components/FeaturePanel/Climbing/contexts/ClimbingContext.tsx
+++ b/src/components/FeaturePanel/Climbing/contexts/ClimbingContext.tsx
@@ -170,6 +170,8 @@ type ClimbingContextType = {
   canUndo: boolean;
   canRedo: boolean;
   deleteLastPathPoint: () => void;
+  isMapVisible: boolean;
+  setIsMapVisible: Setter<boolean>;
 };
 
 // @TODO generate?
@@ -227,6 +229,9 @@ export const ClimbingContextProvider = ({ children, feature }: Props) => {
   const [photoPath, setPhotoPath] = useState<string>(null); // photo URL (pathname), should be null
   const { debugMode: showDebugMenu } = useDebugMode();
   const [isEditMode, setIsEditMode] = useState(false);
+  // Whether the bottom panel shows the map (true) or the route list (false).
+  // Kept in context so the dialog header's overflow menu can toggle it too.
+  const [isMapVisible, setIsMapVisible] = useState<boolean>(false);
   const [imageSize, setImageSize] = useState({ width: 0, height: 0 });
   const [imageContainerSize, setImageContainerSize] = useState({
     width: 0,
@@ -664,6 +669,8 @@ export const ClimbingContextProvider = ({ children, feature }: Props) => {
     canUndo,
     canRedo,
     deleteLastPathPoint,
+    isMapVisible,
+    setIsMapVisible,
   };
 
   return (

--- a/src/locales/cs.js
+++ b/src/locales/cs.js
@@ -885,6 +885,7 @@ export default {
   'wikimedia.logged_out': 'Odhlášen z Wikimedia Commons',
   'route_ticks.title': 'Mé přelezy této cesty',
   'climbing_view.show_route_list': 'Zobrazit seznam cest',
+  'climbing_view.show_map': 'Zobrazit mapu',
   'climbing_grades.selected': 'vybráno',
   'my_ticks.graphs.routes_distribution': 'Rozložení cest',
   'my_ticks.graphs.grouping': 'Seskupit',

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -320,6 +320,7 @@ export default {
   'wikimedia.logged_out': 'Logged out from Wikimedia Commons',
   'route_ticks.title': 'Route ticks',
   'climbing_view.show_route_list': 'Show route list',
+  'climbing_view.show_map': 'Show map',
   'climbing_grades.selected': 'selected',
   'my_ticks.graphs.routes_distribution': 'Routes distribution',
   'my_ticks.graphs.grouping': 'Grouping',


### PR DESCRIPTION
<!--
// Please, remove any section which is not applicable/useful.

### Description

### Example links

### Screenshots

// consider using smaller images, eg. <img src="url" width="500"> instead of ![](url)

### Checklist

- [ ] dark mode / light mode
- [ ] mobile / desktop
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)

-->
