### PR TITLE
climbingTiles: fix outline for crags with one route

### DIFF
--- a/src/components/Map/climbingTiles/__tests__/constructOutlines.test.ts
+++ b/src/components/Map/climbingTiles/__tests__/constructOutlines.test.ts
@@ -106,6 +106,17 @@ describe('constructOutlines', () => {
     );
   });
 
+  it('gives a finite minZoom to a boulder with all routes on one node', () => {
+    const routes = wall(5, 0, 0).map((route) => ({
+      ...route,
+      geometry: { type: 'Point' as const, coordinates: [CRAG_LON, CRAG_LAT] },
+    }));
+
+    const [outline] = constructOutlines([...routes, crag]);
+
+    expect(Number.isFinite(outline.properties.minZoom)).toBe(true);
+  });
+
   it('spans the whole subtree of a nested area, not just its child crags', () => {
     const AREA_ID = 900000;
     const SUB_ID = 900001;

--- a/src/components/Map/climbingTiles/__tests__/outlinesLayer.test.ts
+++ b/src/components/Map/climbingTiles/__tests__/outlinesLayer.test.ts
@@ -5,7 +5,7 @@ const evaluate = (
   property: 'line-opacity' | 'line-width',
   zoom: number,
   featureState: Record<string, unknown>,
-  minZoom = 10,
+  minZoom: number | null = 10,
 ) => {
   const paint = outlinesLayer.paint as Record<string, unknown>;
   const result = expression.createPropertyExpression(
@@ -28,6 +28,12 @@ describe('outlinesLayer', () => {
 
   it('keeps the outline hidden when zoomed out too far', () => {
     expect(evaluate('line-opacity', 8, { hover: true })).toBe(0);
+  });
+
+  it('hides the outline when minZoom is missing', () => {
+    expect(evaluate('line-opacity', 18, {}, null)).toBe(0);
+    expect(evaluate('line-opacity', 18, { hover: true }, null)).toBe(0);
+    expect(evaluate('line-opacity', 18, { selected: true }, null)).toBe(1);
   });
 
   it('shows the outline of the selected feature without hover, in any zoom', () => {

--- a/src/components/Map/climbingTiles/climbingLayers/outlinesLayer.ts
+++ b/src/components/Map/climbingTiles/climbingLayers/outlinesLayer.ts
@@ -24,11 +24,15 @@ const SELECTED: ExpressionSpecification = [
   false,
 ];
 
+// a missing/null minZoom would throw and maplibre would silently fall back to
+// the default line-opacity of 1 - i.e. the outline lit up all the time
+const MIN_ZOOM: ExpressionSpecification = ['coalesce', ['get', 'minZoom'], 99];
+
 const BY_ZOOM = (z: number): ExpressionSpecification => [
   'case',
   SELECTED,
   1,
-  ['>', z, ['get', 'minZoom']],
+  ['>', z, MIN_ZOOM],
   SHOULD_SHOW,
   0,
 ];

--- a/src/components/Map/climbingTiles/constructOutlines.ts
+++ b/src/components/Map/climbingTiles/constructOutlines.ts
@@ -33,7 +33,10 @@ const getMeasures = (hull: GeojsonFeature<Polygon | LineString>) => {
   );
   const inflation = inflationMeters / METERS_PER_BUFFER_DEGREE;
 
-  const minZoom = Math.log2((5 * 40075016) / (diagonalMeters * 256));
+  // routes mapped on a single node give a zero diagonal (--> minZoom Infinity),
+  // yet the outline is still drawn as a circle of the inflation radius
+  const outlineMeters = Math.max(diagonalMeters, 2 * inflationMeters);
+  const minZoom = Math.log2((5 * 40075016) / (outlineMeters * 256));
 
   return { inflation, minZoom };
 };


### PR DESCRIPTION
Boulders with all routes on a single node give a zero diagonal, so minZoom
was Infinity, serialized to null and the layer expression fell back to the
default line-opacity of 1 - the outline was always visible.

https://openclimbing.org/relation/20948435#17.50/45.7102/4.5921

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PHq8CDYphM5EwmB774414P