### PR TITLE
climbingTiles: highlight routes in crag

### DIFF
--- a/src/components/Map/behaviour/featureHover.ts
+++ b/src/components/Map/behaviour/featureHover.ts
@@ -7,6 +7,8 @@ import {
 } from 'maplibre-gl';
 import { climbingLayers } from '../climbingTiles/climbingLayers/climbingLayers';
 import { isMobileDevice } from '../../helpers';
+import { setHoveredCragRoutes } from '../climbingTiles/selectedCragRoutes';
+import { CLIMBING_TILES_SOURCE } from '../climbingTiles/consts';
 
 const HOVER_EXPRESSION = ['case', ['boolean', ['feature-state', 'hover'], false], 0.5, 1]; // prettier-ignore
 const ICON_OPACITY = ['case', ['boolean', ['feature-state', 'hideIcon'], false], 0, HOVER_EXPRESSION]; // prettier-ignore
@@ -27,6 +29,12 @@ const CLIMBING_CLICKABLE_LAYERS = climbingLayers
   .filter((l) => (l.metadata as any)?.clickableWithOsmId)
   .map((l) => l.id);
 
+const getHoveredCragId = (feature: MapGeoJSONFeature | null) =>
+  feature?.source === CLIMBING_TILES_SOURCE &&
+  feature.properties?.type === 'crag'
+    ? (feature.id as number)
+    : undefined;
+
 export const setUpHover = (map: Map, layersWithOsmId: string[]) => {
   let lastHover = null;
 
@@ -39,6 +47,7 @@ export const setUpHover = (map: Map, layersWithOsmId: string[]) => {
     if (feature !== lastHover) {
       setHoverOff(lastHover);
       setHoverOn(feature);
+      setHoveredCragRoutes(getHoveredCragId(feature));
       lastHover = feature;
       map.getCanvas().style.cursor = 'pointer'; // eslint-disable-line no-param-reassign
     }
@@ -55,6 +64,7 @@ export const setUpHover = (map: Map, layersWithOsmId: string[]) => {
 
   const cancelHover = () => {
     setHoverOff(lastHover);
+    setHoveredCragRoutes(undefined);
     lastHover = null;
     // TODO delay 200ms
     map.getCanvas().style.cursor = ''; // eslint-disable-line no-param-reassign

--- a/src/components/Map/climbingTiles/__tests__/selectedCragRoutes.test.ts
+++ b/src/components/Map/climbingTiles/__tests__/selectedCragRoutes.test.ts
@@ -1,0 +1,66 @@
+import { CRAG_ROUTES_LAYER } from '../climbingLayers/routesPoints';
+import {
+  setHoveredCragRoutes,
+  setSelectedCragRoutes,
+} from '../selectedCragRoutes';
+
+const setFilter = jest.fn();
+const map = { getLayer: () => ({}), setFilter };
+
+jest.mock('../../../../services/mapStorage', () => ({
+  getGlobalMap: () => map,
+}));
+
+const lastFilter = () => setFilter.mock.calls.at(-1);
+
+describe('selectedCragRoutes', () => {
+  beforeEach(() => {
+    setFilter.mockClear();
+    setSelectedCragRoutes(undefined);
+    setHoveredCragRoutes(undefined);
+  });
+
+  it('filters the routes by the parent of the selected relation', () => {
+    setSelectedCragRoutes(1234);
+
+    expect(lastFilter()).toEqual([
+      CRAG_ROUTES_LAYER,
+      ['==', ['get', 'parentId'], 123],
+    ]);
+  });
+
+  it('matches nothing when nothing is selected', () => {
+    setSelectedCragRoutes(undefined);
+
+    expect(lastFilter()).toEqual([
+      CRAG_ROUTES_LAYER,
+      ['==', ['get', 'parentId'], -1],
+    ]);
+  });
+
+  it('matches nothing for a node/way - only relations have children', () => {
+    setSelectedCragRoutes(1230);
+
+    expect(lastFilter()).toEqual([
+      CRAG_ROUTES_LAYER,
+      ['==', ['get', 'parentId'], -1],
+    ]);
+  });
+
+  it('lets hover win over the selected crag and falls back to it', () => {
+    setSelectedCragRoutes(1234);
+    setHoveredCragRoutes(5674);
+
+    expect(lastFilter()).toEqual([
+      CRAG_ROUTES_LAYER,
+      ['==', ['get', 'parentId'], 567],
+    ]);
+
+    setHoveredCragRoutes(undefined);
+
+    expect(lastFilter()).toEqual([
+      CRAG_ROUTES_LAYER,
+      ['==', ['get', 'parentId'], 123],
+    ]);
+  });
+});

--- a/src/components/Map/climbingTiles/climbingLayers/routesPoints.ts
+++ b/src/components/Map/climbingTiles/climbingLayers/routesPoints.ts
@@ -18,6 +18,10 @@ const ifHighlighted = (
 
 export const CRAG_ROUTES_LAYER = 'climbing route (crag highlight)';
 
+// circle-blur fades the disc from its edge inwards, so the ring has to start
+// wider to keep a visible thickness
+const HALO = 1.6;
+
 export const routesPoints: LayerSpecification[] = [
   {
     // an orange disc peeking from under the white ring - maplibre has no second
@@ -29,12 +33,14 @@ export const routesPoints: LayerSpecification[] = [
     filter: ['==', ['get', 'parentId'], -1], // set by setSelectedCragRoutes()
     paint: {
       'circle-color': '#f60',
+      'circle-opacity': 0.85,
+      'circle-blur': 1,
       // route radius + its white stroke + the ring itself
       'circle-radius': linear(
         16,
-        ifHighlighted(2 + 2 + 1.5, 1 + 0.4 + 1.5),
+        ifHighlighted((2 + 2 + 1.5) * HALO, (1 + 0.4 + 1.5) * HALO),
         21,
-        ifHighlighted(8 + 5 + 3, 6 + 1.2 + 3),
+        ifHighlighted((8 + 5 + 3) * HALO, (6 + 1.2 + 3) * HALO),
       ),
     },
   },

--- a/src/components/Map/climbingTiles/climbingLayers/routesPoints.ts
+++ b/src/components/Map/climbingTiles/climbingLayers/routesPoints.ts
@@ -1,8 +1,43 @@
-import { LayerSpecification } from '@maplibre/maplibre-gl-style-spec';
+import {
+  ExpressionSpecification,
+  LayerSpecification,
+} from '@maplibre/maplibre-gl-style-spec';
 import { CLIMBING_TILES_SOURCE } from '../consts';
 import { linear } from './helpers';
 
+// route on the clicked photo
+const ifHighlighted = (
+  highlighted: number,
+  basic: number,
+): ExpressionSpecification => [
+  'case',
+  ['boolean', ['feature-state', 'highlighted'], false],
+  highlighted,
+  basic,
+];
+
+export const CRAG_ROUTES_LAYER = 'climbing route (crag highlight)';
+
 export const routesPoints: LayerSpecification[] = [
+  {
+    // an orange disc peeking from under the white ring - maplibre has no second
+    // stroke on a circle, so the ring has to be a layer of its own
+    id: CRAG_ROUTES_LAYER,
+    type: 'circle',
+    source: CLIMBING_TILES_SOURCE,
+    minzoom: 13,
+    filter: ['==', ['get', 'parentId'], -1], // set by setSelectedCragRoutes()
+    paint: {
+      'circle-color': '#f60',
+      // route radius + its white stroke + the ring itself
+      'circle-radius': linear(
+        16,
+        ifHighlighted(2 + 2 + 1.5, 1 + 0.4 + 1.5),
+        21,
+        ifHighlighted(8 + 5 + 3, 6 + 1.2 + 3),
+      ),
+    },
+  },
   {
     id: 'climbing route (circle)',
     metadata: { clickableWithOsmId: true },
@@ -22,21 +57,16 @@ export const routesPoints: LayerSpecification[] = [
         ['coalesce', ['get', 'color'], '#999'],
       ],
       // highlighted (route on the clicked photo) grows its coloured centre a bit
-      'circle-radius': linear(
-        16,
-        ['case', ['boolean', ['feature-state', 'highlighted'], false], 2, 1],
-        21,
-        ['case', ['boolean', ['feature-state', 'highlighted'], false], 8, 6],
-      ),
+      'circle-radius': linear(16, ifHighlighted(2, 1), 21, ifHighlighted(8, 6)),
       'circle-stroke-color': '#ffffff',
       // routes drawn on the currently highlighted photo keep their difficulty
       // colour and same-sized centre, but get a bigger white ring around them.
       // zoom must stay top-level, so the highlighted `case` goes in the outputs
       'circle-stroke-width': linear(
         16,
-        ['case', ['boolean', ['feature-state', 'highlighted'], false], 2, 0.4],
+        ifHighlighted(2, 0.4),
         21,
-        ['case', ['boolean', ['feature-state', 'highlighted'], false], 5, 1.2],
+        ifHighlighted(5, 1.2),
       ),
     },
   },

--- a/src/components/Map/climbingTiles/selectedCragRoutes.ts
+++ b/src/components/Map/climbingTiles/selectedCragRoutes.ts
@@ -1,0 +1,42 @@
+import { FilterSpecification } from '@maplibre/maplibre-gl-style-spec';
+import { getGlobalMap } from '../../../services/mapStorage';
+import { CRAG_ROUTES_LAYER } from './climbingLayers/routesPoints';
+
+// routes carry the plain osm id of their parent relation, the map id has the
+// type digit appended (see convertOsmIdToMapId)
+const toParentId = (mapId: number | undefined) =>
+  mapId !== undefined && mapId % 10 === 4 ? Math.floor(mapId / 10) : -1;
+
+const getFilter = (mapId: number | undefined): FilterSpecification => [
+  '==',
+  ['get', 'parentId'],
+  toParentId(mapId),
+];
+
+let selectedId: number | undefined = undefined;
+let hoveredId: number | undefined = undefined;
+
+const apply = () => {
+  const map = getGlobalMap();
+  if (!map?.getLayer(CRAG_ROUTES_LAYER)) {
+    return;
+  }
+  map.setFilter(CRAG_ROUTES_LAYER, getFilter(hoveredId ?? selectedId));
+};
+
+export const setSelectedCragRoutes = (mapId: number | undefined) => {
+  selectedId = mapId;
+  apply();
+};
+
+export const setHoveredCragRoutes = (mapId: number | undefined) => {
+  if (mapId === hoveredId) {
+    return;
+  }
+  hoveredId = mapId;
+  apply();
+};
+
+// the layer is recreated whenever the style is rebuilt - the filter is not
+// part of the layer spec, so it has to be set again
+export const reapplySelectedCragRoutes = apply;

--- a/src/components/Map/climbingTiles/selectedOutline.ts
+++ b/src/components/Map/climbingTiles/selectedOutline.ts
@@ -1,5 +1,9 @@
 import { getGlobalMap } from '../../../services/mapStorage';
 import { CLIMBING_TILES_SOURCE } from './consts';
+import {
+  reapplySelectedCragRoutes,
+  setSelectedCragRoutes,
+} from './selectedCragRoutes';
 
 let selectedId: number | undefined = undefined;
 
@@ -21,10 +25,12 @@ export const setSelectedOutline = (id: number | undefined) => {
   setState(selectedId, false);
   selectedId = id;
   setState(selectedId, true);
+  setSelectedCragRoutes(id);
 };
 
 // the source (or the whole style) is rebuilt behind our back - the feature
 // state has to be applied again once the new data is in
 export const reapplySelectedOutline = () => {
   setState(selectedId, true);
+  reapplySelectedCragRoutes();
 };


### PR DESCRIPTION
### Description

Routes of the selected (or hovered) crag get an orange halo, so it is visible at a glance which routes belong to it.

Maplibre has no second stroke and no gradient on a `circle` layer, so the halo is a separate blurred circle layer underneath the route dots, switched on by a filter on `parentId`.

### Example links

https://openclimbing-preview-git-claude-crag-outlin-23548f-openclimbing.vercel.app/relation/17470992#18.71/49.9505/14.1241

Claude-Session: https://claude.ai/code/session_01PjqYfFynWA5S469jaSWAUB