### PR TITLE
climbingTiles: black halo on crag routes

### DIFF
--- a/src/components/Map/climbingTiles/climbingLayers/routesPoints.ts
+++ b/src/components/Map/climbingTiles/climbingLayers/routesPoints.ts
@@ -24,15 +24,15 @@ const HALO = 1.6;
 
 export const routesPoints: LayerSpecification[] = [
   {
-    // an orange disc peeking from under the white ring - maplibre has no second
-    // stroke on a circle, so the ring has to be a layer of its own
+    // a disc peeking from under the white ring - maplibre has no second stroke
+    // on a circle, so the ring has to be a layer of its own
     id: CRAG_ROUTES_LAYER,
     type: 'circle',
     source: CLIMBING_TILES_SOURCE,
     minzoom: 13,
     filter: ['==', ['get', 'parentId'], -1], // set by setSelectedCragRoutes()
     paint: {
-      'circle-color': '#f60',
+      'circle-color': '#ffffff',
       'circle-opacity': 0.85,
       'circle-blur': 1,
       // route radius + its white stroke + the ring itself

--- a/src/components/Map/climbingTiles/climbingLayers/routesPoints.ts
+++ b/src/components/Map/climbingTiles/climbingLayers/routesPoints.ts
@@ -32,7 +32,7 @@ export const routesPoints: LayerSpecification[] = [
     minzoom: 13,
     filter: ['==', ['get', 'parentId'], -1], // set by setSelectedCragRoutes()
     paint: {
-      'circle-color': '#ffffff',
+      'circle-color': '#000000',
       'circle-opacity': 0.85,
       'circle-blur': 1,
       // route radius + its white stroke + the ring itself


### PR DESCRIPTION
### Description

Tries the halo around the routes of the selected crag in black instead of orange - nothing else changes. (The branch name still says `white`, that was the first colour tried here.)

### Example links

https://openclimbing-preview-git-claude-crag-ring-white-openclimbing.vercel.app/relation/17470992#18.71/49.9505/14.1241

Claude-Session: https://claude.ai/code/session_01PjqYfFynWA5S469jaSWAUB