### PR TITLE
HamburgerMenu: fix hidden LangSwitcher

### DIFF
--- a/src/components/Map/HamburgerMenu/HamburgerMenu.tsx
+++ b/src/components/Map/HamburgerMenu/HamburgerMenu.tsx
@@ -36,6 +36,11 @@ import { MyListsSection } from './MyListsSection';
 import { useOsmAuthContext } from '../../utils/OsmAuthContext';
 import ContrastIcon from '@mui/icons-material/Contrast';
 import { UserSettingsDialog } from '../../HomepagePanel/UserSettingsDialog';
+import { Theme, ThemeProvider } from '@mui/material/styles';
+import {
+  HAMBURGER_DRAWER_Z,
+  HAMBURGER_OVERLAY_Z,
+} from '../../utils/mapChromeRegistry';
 
 const StyledGithubIcon = styled(GithubIcon)`
   filter: ${({ theme }) => theme.palette.invertFilter};
@@ -165,6 +170,17 @@ const ThemeSelection = () => {
   );
 };
 
+// MUI has no modal stacking - everything opened from inside the drawer would
+// render at theme.zIndex.modal (1300), ie. under the drawer itself
+const overlayTheme = (theme: Theme) => ({
+  ...theme,
+  zIndex: {
+    ...theme.zIndex,
+    modal: HAMBURGER_OVERLAY_Z,
+    tooltip: HAMBURGER_OVERLAY_Z + 1,
+  },
+});
+
 // TODO custom Item components are not keyboard accesible
 // seems like a bug in material-ui
 // https://github.com/mui-org/material-ui/issues/22912
@@ -198,54 +214,67 @@ export const HamburgerMenu = () => {
         onClose={close}
         anchor="right"
         // above map controls (1300) and the layers panel (1200)
-        sx={{ zIndex: 1500 }}
+        sx={{ zIndex: HAMBURGER_DRAWER_Z }}
       >
-        <Stack direction="column" justifyContent="space-between" height="100%">
-          <div>
-            <UserHeader
-              closeMenu={close}
-              openUserSettings={handleOpenUserSettings}
-            />
-            <Divider sx={{ mt: 1, mb: 2 }} />
-            {isOpenClimbing && <MyClimbingProfileMenuItem closeMenu={close} />}
-            {isMobileMode && (
-              <>
-                <ClimbingAreasLink closeMenu={close} />
-                <AboutLink closeMenu={close} />
-              </>
-            )}
-            {loggedIn && (
-              <>
-                <Divider sx={{ my: 1 }} />
-                <MyListsSection closeMenu={close} />
-                <Divider sx={{ my: 1 }} />
-              </>
-            )}
-            {(hasClimbingLayer || isOpenClimbing) && (
-              <>
-                <ClimbingGradesTableLink closeMenu={close} />
-                <TickScoringLink closeMenu={close} />
-                {isOpenClimbing && (
-                  <ClimbingLeaderboardLink closeMenu={close} />
-                )}
-              </>
-            )}
-          </div>
-          <div>
-            <Divider />
-            <Box mb={2}>
-              <EditLink />
-            </Box>
-            <Divider />
-            <Stack direction="row" justifyContent="space-between" mb={1} mt={1}>
-              <LangSwitcher />
-              <div>
-                <ThemeSelection />
-                <GithubLink />
-              </div>
-            </Stack>
-          </div>
-        </Stack>
+        <ThemeProvider theme={overlayTheme}>
+          <Stack
+            direction="column"
+            justifyContent="space-between"
+            height="100%"
+          >
+            <div>
+              <UserHeader
+                closeMenu={close}
+                openUserSettings={handleOpenUserSettings}
+              />
+              <Divider sx={{ mt: 1, mb: 2 }} />
+              {isOpenClimbing && (
+                <MyClimbingProfileMenuItem closeMenu={close} />
+              )}
+              {isMobileMode && (
+                <>
+                  <ClimbingAreasLink closeMenu={close} />
+                  <AboutLink closeMenu={close} />
+                </>
+              )}
+              {loggedIn && (
+                <>
+                  <Divider sx={{ my: 1 }} />
+                  <MyListsSection closeMenu={close} />
+                  <Divider sx={{ my: 1 }} />
+                </>
+              )}
+              {(hasClimbingLayer || isOpenClimbing) && (
+                <>
+                  <ClimbingGradesTableLink closeMenu={close} />
+                  <TickScoringLink closeMenu={close} />
+                  {isOpenClimbing && (
+                    <ClimbingLeaderboardLink closeMenu={close} />
+                  )}
+                </>
+              )}
+            </div>
+            <div>
+              <Divider />
+              <Box mb={2}>
+                <EditLink />
+              </Box>
+              <Divider />
+              <Stack
+                direction="row"
+                justifyContent="space-between"
+                mb={1}
+                mt={1}
+              >
+                <LangSwitcher />
+                <div>
+                  <ThemeSelection />
+                  <GithubLink />
+                </div>
+              </Stack>
+            </div>
+          </Stack>
+        </ThemeProvider>
       </Drawer>
 
       <HamburgerMenuButton anchorRef={anchorRef} onClick={open} />

--- a/src/components/utils/mapChromeRegistry.ts
+++ b/src/components/utils/mapChromeRegistry.ts
@@ -3,6 +3,7 @@ import type { Snap } from './drawerSnap';
 
 /**
  * Stacking for map chrome:
+ *   hamburger overlays   1600  (dialogs/menus opened from inside the hamburger)
  *   hamburger            1500
  *   bottom-right raised  1300  (layers panel open – button must stay on top)
  *   drawer / layers      1200
@@ -11,6 +12,8 @@ import type { Snap } from './drawerSnap';
 export const BOTTOM_RIGHT_Z_DEFAULT = 1100;
 export const BOTTOM_RIGHT_Z_RAISED = 1300;
 export const LAYERS_DRAWER_Z = 1200;
+export const HAMBURGER_DRAWER_Z = 1500;
+export const HAMBURGER_OVERLAY_Z = 1600;
 
 type ChromeState = {
   layersOpen: boolean;


### PR DESCRIPTION
### Description

Menus and dialogs opened from the hamburger drawer (language switcher, my-lists kebab / create / edit) rendered underneath it, because the drawer sits at z-index 1500 while MUI puts all modals at 1300.

Fixed by wrapping the drawer content in a `ThemeProvider` that raises `zIndex.modal` locally, so current and future overlays stack correctly. Follow-up to #170, which fixed the settings dialog.

### Checklist

- [x] mobile / desktop
- [ ] dark mode / light mode
- [ ] server-side-rendering (SSR)
- [ ] all texts are localized (in vocabulary.ts)

https://claude.ai/code/session_0126v1GydcHQ4cK8Hpf4ssLF

---
_Generated by [Claude Code](https://claude.ai/code/session_0126v1GydcHQ4cK8Hpf4ssLF)_