### PR TITLE
climbingTiles: half opacity for the route highlight

### DIFF
--- a/src/components/Map/climbingTiles/__tests__/outlinesLayer.test.ts
+++ b/src/components/Map/climbingTiles/__tests__/outlinesLayer.test.ts
@@ -23,7 +23,7 @@ const evaluate = (
 describe('outlinesLayer', () => {
   it('hides the outline until hovered', () => {
     expect(evaluate('line-opacity', 14, {})).toBe(0);
-    expect(evaluate('line-opacity', 14, { hover: true })).toBe(0.5);
+    expect(evaluate('line-opacity', 14, { hover: true })).toBe(0.3);
   });
 
   it('keeps the outline hidden when zoomed out too far', () => {
@@ -33,12 +33,12 @@ describe('outlinesLayer', () => {
   it('hides the outline when minZoom is missing', () => {
     expect(evaluate('line-opacity', 18, {}, null)).toBe(0);
     expect(evaluate('line-opacity', 18, { hover: true }, null)).toBe(0);
-    expect(evaluate('line-opacity', 18, { selected: true }, null)).toBe(0.5);
+    expect(evaluate('line-opacity', 18, { selected: true }, null)).toBe(0.3);
   });
 
   it('shows the outline of the selected feature without hover, in any zoom', () => {
-    expect(evaluate('line-opacity', 14, { selected: true })).toBe(0.5);
-    expect(evaluate('line-opacity', 8, { selected: true })).toBe(0.5);
+    expect(evaluate('line-opacity', 14, { selected: true })).toBe(0.3);
+    expect(evaluate('line-opacity', 8, { selected: true })).toBe(0.3);
     expect(evaluate('line-width', 14, { selected: true })).toBe(3);
     expect(evaluate('line-width', 14, {})).toBe(2);
   });

--- a/src/components/Map/climbingTiles/__tests__/outlinesLayer.test.ts
+++ b/src/components/Map/climbingTiles/__tests__/outlinesLayer.test.ts
@@ -23,7 +23,7 @@ const evaluate = (
 describe('outlinesLayer', () => {
   it('hides the outline until hovered', () => {
     expect(evaluate('line-opacity', 14, {})).toBe(0);
-    expect(evaluate('line-opacity', 14, { hover: true })).toBe(1);
+    expect(evaluate('line-opacity', 14, { hover: true })).toBe(0.5);
   });
 
   it('keeps the outline hidden when zoomed out too far', () => {
@@ -33,12 +33,12 @@ describe('outlinesLayer', () => {
   it('hides the outline when minZoom is missing', () => {
     expect(evaluate('line-opacity', 18, {}, null)).toBe(0);
     expect(evaluate('line-opacity', 18, { hover: true }, null)).toBe(0);
-    expect(evaluate('line-opacity', 18, { selected: true }, null)).toBe(1);
+    expect(evaluate('line-opacity', 18, { selected: true }, null)).toBe(0.5);
   });
 
   it('shows the outline of the selected feature without hover, in any zoom', () => {
-    expect(evaluate('line-opacity', 14, { selected: true })).toBe(1);
-    expect(evaluate('line-opacity', 8, { selected: true })).toBe(1);
+    expect(evaluate('line-opacity', 14, { selected: true })).toBe(0.5);
+    expect(evaluate('line-opacity', 8, { selected: true })).toBe(0.5);
     expect(evaluate('line-width', 14, { selected: true })).toBe(3);
     expect(evaluate('line-width', 14, {})).toBe(2);
   });

--- a/src/components/Map/climbingTiles/climbingLayers/outlinesLayer.ts
+++ b/src/components/Map/climbingTiles/climbingLayers/outlinesLayer.ts
@@ -5,7 +5,7 @@ import {
 } from '@maplibre/maplibre-gl-style-spec';
 import { CLIMBING_TILES_SOURCE } from '../consts';
 
-const OPACITY = 0.5;
+const OPACITY = 0.3;
 
 const HOVER: ExpressionSpecification = [
   'case',

--- a/src/components/Map/climbingTiles/climbingLayers/outlinesLayer.ts
+++ b/src/components/Map/climbingTiles/climbingLayers/outlinesLayer.ts
@@ -5,16 +5,18 @@ import {
 } from '@maplibre/maplibre-gl-style-spec';
 import { CLIMBING_TILES_SOURCE } from '../consts';
 
+const OPACITY = 0.5;
+
 const HOVER: ExpressionSpecification = [
   'case',
   ['boolean', ['feature-state', 'hover'], false],
-  1,
+  OPACITY,
   0,
 ];
 
 const SHOULD_SHOW: ExpressionInputType | ExpressionSpecification =
   global.window?.localStorage.getItem('show_all_climbing_outlines') === 'true'
-    ? 1
+    ? OPACITY
     : HOVER;
 
 // feature opened in the FeaturePanel - it stays lit regardless of hover/zoom
@@ -31,7 +33,7 @@ const MIN_ZOOM: ExpressionSpecification = ['coalesce', ['get', 'minZoom'], 99];
 const BY_ZOOM = (z: number): ExpressionSpecification => [
   'case',
   SELECTED,
-  1,
+  OPACITY,
   ['>', z, MIN_ZOOM],
   SHOULD_SHOW,
   0,


### PR DESCRIPTION
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TP6SAS73H2thquP7n1ihor