### PR TITLE
climbingTiles: opacity of route highlight to 0.4

### DIFF
--- a/src/components/Map/climbingTiles/climbingLayers/routesPoints.ts
+++ b/src/components/Map/climbingTiles/climbingLayers/routesPoints.ts
@@ -33,7 +33,7 @@ export const routesPoints: LayerSpecification[] = [
     filter: ['==', ['get', 'parentId'], -1], // set by setSelectedCragRoutes()
     paint: {
       'circle-color': '#f60',
-      'circle-opacity': 0.85,
+      'circle-opacity': 0.4,
       'circle-blur': 1,
       // route radius + its white stroke + the ring itself
       'circle-radius': linear(


### PR DESCRIPTION
### Description

Reduced the opacity of route point circles on the climbing map from 0.85 to 0.4 to improve visibility of underlying map features and reduce visual clutter.

### Checklist

- [x] dark mode / light mode
- [x] mobile / desktop

https://claude.ai/code/session_01AmkeejvktUJShp5NvyD72P