### PR TITLE
chore: add Dependabot config for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Adds a basic Dependabot config -- weekly checks for npm dependencies and GitHub Actions versions, capped at 5 open PRs each. Nothing opinionated beyond that (no grouping, no custom commit prefixes) -- happy to adjust to whatever conventions you'd prefer.

This PR was drafted with Claude Code's help.