### PR TITLE
EditDialog: draw routes over images

### DIFF
--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/WikimediaCommonsGallery.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/WikimediaCommonsGallery.tsx
@@ -13,6 +13,7 @@ import {
   slotsFromFileKeysOrder,
 } from './wikimediaCommonsGalleryModel';
 import { WikimediaCommonsGalleryRow } from './WikimediaCommonsGalleryRow';
+import { useWikimediaCommonsPhotoPaths } from './useWikimediaCommonsPhotoPaths';
 
 const normalizeWikimediaCommonsInput = (raw: string) =>
   decodeURI(
@@ -34,6 +35,7 @@ export const WikimediaCommonsGallery: React.FC<Props> = ({
   const { tags, setTag, setTagsEntries } = useCurrentItem();
   const { highlightedPhoto } = usePhotoHighlightContext();
   const highlightedKey = highlightedPhoto && photoNameKey(highlightedPhoto);
+  const pathsByFileKey = useWikimediaCommonsPhotoPaths(fileKeys);
 
   const applySlotsAndSyncKeys = (
     slotList: ReturnType<typeof slotsFromFileKeysOrder>,
@@ -93,6 +95,7 @@ export const WikimediaCommonsGallery: React.FC<Props> = ({
                 index={index}
                 value={value}
                 focusTag={focusTag}
+                paths={pathsByFileKey[fileKey]}
                 highlighted={highlighted}
                 onValueChange={onValueChange}
                 onRemove={() => removeRow(index)}

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/WikimediaCommonsGalleryRow.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/WikimediaCommonsGalleryRow.tsx
@@ -15,6 +15,7 @@ import { t } from '../../../../../services/intl';
 import { TextFieldWithCharacterCount } from './helpers';
 import { WikimediaCommonsThumb } from './WikimediaCommonsThumb';
 import { useOptionalEditDialogUploadContext } from '../../EditDialogUploadContext';
+import { PathWithTags } from '../../../FeatureImages/PathsSvg';
 
 const isWikimediaCommonsFileNameInvalid = (value: string) => {
   const regex = /^File:.+\.[a-zA-Z0-9_]+$/;
@@ -37,6 +38,8 @@ type Props = {
   dragHandle?: React.ReactNode;
   highlighted?: boolean;
   rowRef?: React.Ref<HTMLDivElement>;
+  /** Route lines drawn on this photo, from this item and its loaded members. */
+  paths?: PathWithTags[];
 };
 
 type EmptyRowCtaProps = {
@@ -92,6 +95,7 @@ export const WikimediaCommonsGalleryRow: React.FC<Props> = ({
   dragHandle,
   highlighted,
   rowRef,
+  paths,
 }) => {
   const uploadCtx = useOptionalEditDialogUploadContext();
   const canUpload = Boolean(uploadCtx);
@@ -127,6 +131,7 @@ export const WikimediaCommonsGalleryRow: React.FC<Props> = ({
           {dragHandle != null && <Box>{dragHandle}</Box>}
           <WikimediaCommonsThumb
             value={value}
+            paths={paths}
             onPlaceholderClick={
               canUpload && isEmpty ? handleUploadClick : undefined
             }

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/WikimediaCommonsThumb.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/WikimediaCommonsThumb.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Box, Link, Tooltip } from '@mui/material';
 import ImageOutlined from '@mui/icons-material/ImageOutlined';
 import { getCommonsImageUrl } from '../../../../../services/images/getCommonsImageUrl';
 import type { CommonsAllowedWidth } from '../../../../../services/images/getCommonsImageUrl';
 import { getUrlForTag } from '../../../Properties/getUrlForTag';
 import { t } from '../../../../../services/intl';
+import { PathsOverlaySvg, PathWithTags } from '../../../FeatureImages/PathsSvg';
+import { Size } from '../../../FeatureImages/types';
 
 const WIKIMEDIA_COMMONS_UPLOAD_WIZARD_URL =
   'https://commons.wikimedia.org/wiki/Special:UploadWizard';
@@ -18,11 +20,83 @@ const isValidFileThumb = (value: string) => {
   return Boolean(value) && regex.test(value);
 };
 
+// Letterbox the photo inside the fixed thumb box, so the drawn lines – which
+// are in relative photo coordinates – land where they belong. Cropping the
+// photo (object-fit: cover) would shift them.
+const fitIntoThumbBox = (ratio: number): Size =>
+  ratio >= THUMB_BOX_WIDTH / THUMB_BOX_HEIGHT
+    ? { width: THUMB_BOX_WIDTH, height: Math.round(THUMB_BOX_WIDTH / ratio) }
+    : { width: Math.round(THUMB_BOX_HEIGHT * ratio), height: THUMB_BOX_HEIGHT };
+
+const useImageRatio = (src: string | null) => {
+  const [ratio, setRatio] = useState<number | null>(null);
+
+  useEffect(() => {
+    setRatio(null);
+  }, [src]);
+
+  const onLoad = (e: React.SyntheticEvent<HTMLImageElement>) => {
+    const { naturalWidth, naturalHeight } = e.currentTarget;
+    if (naturalWidth && naturalHeight) {
+      setRatio(naturalWidth / naturalHeight);
+    }
+  };
+
+  return { ratio, onLoad };
+};
+
+type ThumbImageProps = {
+  src: string;
+  paths: PathWithTags[];
+};
+
+const ThumbImage: React.FC<ThumbImageProps> = ({ src, paths }) => {
+  const { ratio, onLoad } = useImageRatio(src);
+
+  const img = (
+    <Box
+      component="img"
+      src={src}
+      alt=""
+      onLoad={onLoad}
+      sx={{
+        display: 'block',
+        width: '100%',
+        height: '100%',
+        objectFit: paths.length ? 'contain' : 'cover',
+      }}
+    />
+  );
+
+  if (!paths.length) {
+    return img;
+  }
+
+  // until the photo is loaded we don't know where it sits inside the box
+  const size = ratio == null ? null : fitIntoThumbBox(ratio);
+
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        width: size ? size.width : '100%',
+        height: size ? size.height : '100%',
+        opacity: 0.9, // same slight dim as in the feature panel gallery
+      }}
+    >
+      {img}
+      {size && <PathsOverlaySvg paths={paths} size={size} />}
+    </Box>
+  );
+};
+
 type Props = {
   value: string;
   /** When provided and value is empty, clicking the placeholder calls this
    * handler instead of opening the Commons Upload Wizard. */
   onPlaceholderClick?: () => void;
+  /** Route lines (`…:path` tags) drawn over the photo. */
+  paths?: PathWithTags[];
 };
 
 const thumbBoxSx = {
@@ -40,6 +114,7 @@ const thumbBoxSx = {
 export const WikimediaCommonsThumb: React.FC<Props> = ({
   value,
   onPlaceholderClick,
+  paths,
 }) => {
   const trimmed = value.trim();
   const thumbUrl =
@@ -52,16 +127,7 @@ export const WikimediaCommonsThumb: React.FC<Props> = ({
     : null;
 
   const inner = thumbUrl ? (
-    <Box
-      component="img"
-      src={thumbUrl}
-      alt=""
-      sx={{
-        width: '100%',
-        height: '100%',
-        objectFit: 'cover',
-      }}
-    />
+    <ThumbImage src={thumbUrl} paths={paths ?? []} />
   ) : (
     <ImageOutlined color="disabled" sx={{ fontSize: 48 }} />
   );

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/__tests__/wikimediaCommonsPhotoPaths.test.ts
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/__tests__/wikimediaCommonsPhotoPaths.test.ts
@@ -1,0 +1,97 @@
+import { collectPhotoPaths, PathSource } from '../wikimediaCommonsPhotoPaths';
+
+const crag: PathSource = {
+  shortId: 'r1',
+  tags: {
+    wikimedia_commons: 'File:Photo one.jpg',
+    'wikimedia_commons:2': 'File:Photo two.jpg',
+  },
+};
+
+const route = (shortId: string, photo: string, path: string): PathSource => ({
+  shortId,
+  tags: {
+    wikimedia_commons: photo,
+    'wikimedia_commons:path': path,
+    'climbing:grade:uiaa': '6',
+  },
+});
+
+const fileKeys = ['wikimedia_commons', 'wikimedia_commons:2'];
+
+describe('collectPhotoPaths', () => {
+  it('returns no paths when nothing is drawn', () => {
+    expect(collectPhotoPaths(crag, [], fileKeys)).toEqual({
+      wikimedia_commons: [],
+      'wikimedia_commons:2': [],
+    });
+  });
+
+  it('collects member paths onto the photo they are drawn on', () => {
+    const members = [
+      route('n1', 'File:Photo one.jpg', '0.1,0.2|0.3,0.4'),
+      route('n2', 'File:Photo two.jpg', '0.5,0.6|0.7,0.8'),
+    ];
+
+    const result = collectPhotoPaths(crag, members, fileKeys);
+
+    expect(result['wikimedia_commons'].map(({ key }) => key)).toEqual([
+      'n1-wikimedia_commons',
+    ]);
+    expect(result['wikimedia_commons:2'].map(({ key }) => key)).toEqual([
+      'n2-wikimedia_commons',
+    ]);
+    expect(result['wikimedia_commons'][0].path).toEqual([
+      { x: 0.1, y: 0.2, suffix: '' },
+      { x: 0.3, y: 0.4, suffix: '' },
+    ]);
+    expect(result['wikimedia_commons'][0].tags).toBe(members[0].tags);
+  });
+
+  it('matches photos regardless of underscores and the File: prefix', () => {
+    const members = [route('n1', 'Photo_one.jpg', '0.1,0.2|0.3,0.4')];
+
+    expect(
+      collectPhotoPaths(crag, members, fileKeys)['wikimedia_commons'],
+    ).toHaveLength(0); // value without `File:` is not a photo slot
+
+    const prefixed = [route('n2', 'File:Photo_one.jpg', '0.1,0.2|0.3,0.4')];
+    expect(
+      collectPhotoPaths(crag, prefixed, fileKeys)['wikimedia_commons'],
+    ).toHaveLength(1);
+  });
+
+  it('includes the item own path and skips single-point paths', () => {
+    const item: PathSource = {
+      shortId: 'n9',
+      tags: {
+        wikimedia_commons: 'File:Photo one.jpg',
+        'wikimedia_commons:path': '0.1,0.2|0.3,0.4',
+        'wikimedia_commons:2': 'File:Photo two.jpg',
+        'wikimedia_commons:2:path': '0.5,0.6',
+      },
+    };
+
+    const result = collectPhotoPaths(item, [], fileKeys);
+
+    expect(result['wikimedia_commons'].map(({ key }) => key)).toEqual([
+      'n9-wikimedia_commons',
+    ]);
+    expect(result['wikimedia_commons:2']).toEqual([]);
+  });
+
+  it('reacts to the photo the slot currently points at', () => {
+    const members = [route('n1', 'File:Photo two.jpg', '0.1,0.2|0.3,0.4')];
+    const retargeted: PathSource = {
+      ...crag,
+      tags: { ...crag.tags, wikimedia_commons: 'File:Photo two.jpg' },
+    };
+
+    expect(
+      collectPhotoPaths(crag, members, fileKeys)['wikimedia_commons'],
+    ).toHaveLength(0);
+    expect(
+      collectPhotoPaths(retargeted, members, fileKeys)['wikimedia_commons'],
+    ).toHaveLength(1);
+  });
+});

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/useWikimediaCommonsPhotoPaths.ts
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/useWikimediaCommonsPhotoPaths.ts
@@ -1,0 +1,55 @@
+import { useMemo } from 'react';
+import { getShortId } from '../../../../../services/helpers';
+import { PathWithTags } from '../../../FeatureImages/PathsSvg';
+import { useCurrentItem, useEditContext } from '../../context/EditContext';
+import { useEditDialogFeature } from '../../utils';
+import { collectPhotoPaths, PathSource } from './wikimediaCommonsPhotoPaths';
+
+/**
+ * Members of the currently edited item as path sources. Members already loaded
+ * into EditContext win, so the preview reacts live to the tags being edited;
+ * the rest falls back to the member features loaded with the feature panel, so
+ * the lines are there before the user opens any member.
+ */
+const useMemberPathSources = (): PathSource[] => {
+  const { items } = useEditContext();
+  const { shortId, members } = useCurrentItem();
+  const { feature } = useEditDialogFeature();
+
+  return useMemo(() => {
+    const isSameFeature =
+      feature?.osmMeta && getShortId(feature.osmMeta) === shortId;
+    const memberFeatures = isSameFeature ? feature.memberFeatures : undefined;
+
+    return (members ?? [])
+      .map((member) => {
+        const item = items.find(({ shortId: id }) => id === member.shortId);
+        if (item) {
+          return item.toBeDeleted
+            ? undefined
+            : { shortId: item.shortId, tags: item.tags };
+        }
+
+        const memberFeature = memberFeatures?.find(
+          ({ osmMeta }) => getShortId(osmMeta) === member.shortId,
+        );
+        return memberFeature
+          ? { shortId: member.shortId, tags: memberFeature.tags }
+          : undefined;
+      })
+      .filter((source) => source != null);
+  }, [feature, items, members, shortId]);
+};
+
+/** Lines to draw over each photo preview of the currently edited item. */
+export const useWikimediaCommonsPhotoPaths = (
+  fileKeys: string[],
+): Record<string, PathWithTags[]> => {
+  const { shortId, tags } = useCurrentItem();
+  const memberSources = useMemberPathSources();
+
+  return useMemo(
+    () => collectPhotoPaths({ shortId, tags }, memberSources, fileKeys),
+    [fileKeys, memberSources, shortId, tags],
+  );
+};

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/wikimediaCommonsPhotoPaths.ts
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/wikimediaCommonsPhotoPaths.ts
@@ -1,0 +1,67 @@
+import { FeatureTags } from '../../../../../services/types';
+import { parsePathTag } from '../../../../../services/images/getImageDefs';
+import {
+  getWikimediaCommonsPhotoTags,
+  pathKeyForWikimediaCommonsFileKey,
+  photoNameKey,
+} from '../../../Climbing/utils/photo';
+import { PathWithTags } from '../../../FeatureImages/PathsSvg';
+
+/** Anything that can own a drawn line – an EditContext item or a member feature. */
+export type PathSource = { shortId: string; tags: FeatureTags };
+
+const getPath = (tags: FeatureTags, fileKey: string) => {
+  const path = parsePathTag(tags[pathKeyForWikimediaCommonsFileKey(fileKey)]);
+  return path && path.length > 1 ? path : undefined; // a single point is not a line
+};
+
+// All slots of one source pointing at `photoKey`, with their drawn line (if any).
+const getPathsOnPhoto = (
+  { shortId, tags }: PathSource,
+  photoKey: string,
+): PathWithTags[] =>
+  getWikimediaCommonsPhotoTags(tags)
+    .filter(([, value]) => photoNameKey(value) === photoKey)
+    .map(([fileKey]) => ({
+      key: `${shortId}-${fileKey}`,
+      path: getPath(tags, fileKey),
+      tags,
+    }))
+    .filter(({ path }) => path != null);
+
+/**
+ * Lines drawn on the photos of `item`, keyed by its `wikimedia_commons*` slot –
+ * the item's own `…:path` tag plus the paths its members drew on the same photo.
+ */
+export const collectPhotoPaths = (
+  item: PathSource,
+  memberSources: PathSource[],
+  fileKeys: string[],
+): Record<string, PathWithTags[]> =>
+  Object.fromEntries(
+    fileKeys.map((fileKey) => {
+      const photoKey = photoNameKey(item.tags[fileKey]);
+      if (!photoKey) {
+        return [fileKey, []];
+      }
+
+      const ownPath = getPath(item.tags, fileKey);
+      return [
+        fileKey,
+        [
+          ...(ownPath
+            ? [
+                {
+                  key: `${item.shortId}-${fileKey}`,
+                  path: ownPath,
+                  tags: item.tags,
+                },
+              ]
+            : []),
+          ...memberSources.flatMap((source) =>
+            getPathsOnPhoto(source, photoKey),
+          ),
+        ],
+      ];
+    }),
+  );

--- a/src/components/FeaturePanel/FeatureImages/PathsSvg.tsx
+++ b/src/components/FeaturePanel/FeatureImages/PathsSvg.tsx
@@ -4,6 +4,7 @@ import { useTheme } from '@emotion/react';
 
 import {
   Feature,
+  FeatureTags,
   ImageDef,
   ImageDefFromTag,
   isTag,
@@ -54,20 +55,20 @@ const PathLine = styled.path<{ $color: string }>`
 
 type PathProps = {
   path: PathType;
-  feature: Feature;
+  tags: FeatureTags;
   size: Size;
   isHighlighted?: boolean;
 };
 const Path = ({
   path,
-  feature,
+  tags,
   size: { height, width },
   isHighlighted = false,
 }: PathProps) => {
   const theme = useTheme();
   const color = isHighlighted
     ? theme.palette.climbing.selected
-    : getDifficultyColor(getDifficulty(feature.tags), theme.palette.mode);
+    : getDifficultyColor(getDifficulty(tags), theme.palette.mode);
   const contrastColor = theme.palette.getContrastText(color);
   const d = path
     .map(({ x, y }, idx) => `${!idx ? 'M' : 'L'}${x * width} ${y * height}`)
@@ -91,12 +92,12 @@ export const Paths = ({ def, feature, size }: PathsProps) => {
   return (
     isTag(def) && (
       <>
-        {def.path && <Path path={def.path} feature={feature} size={size} />}
+        {def.path && <Path path={def.path} tags={feature.tags} size={size} />}
         {def.memberPaths?.map(({ path, member }) => (
           <Path
             key={getReactKey(member)}
             path={path}
-            feature={member}
+            tags={member.tags}
             size={size}
             isHighlighted={preview === member}
           />
@@ -118,3 +119,31 @@ export const PathsSvg = ({ def, size }: PathsSvgProps) => {
     </Svg>
   );
 };
+
+// A path drawn on a photo, decoupled from Feature/ImageDef – so the same
+// rendering can be used where only tags are available (eg. the edit dialog,
+// which draws from the live EditContext items instead of loaded features).
+export type PathWithTags = {
+  key: string;
+  path: PathType;
+  tags: FeatureTags;
+  isHighlighted?: boolean;
+};
+
+type PathsOverlaySvgProps = {
+  paths: PathWithTags[];
+  size: Size;
+};
+export const PathsOverlaySvg = ({ paths, size }: PathsOverlaySvgProps) => (
+  <Svg size={size}>
+    {paths.map(({ key, path, tags, isHighlighted }) => (
+      <Path
+        key={key}
+        path={path}
+        tags={tags}
+        size={size}
+        isHighlighted={isHighlighted}
+      />
+    ))}
+  </Svg>
+);

--- a/src/services/images/getImageDefs.ts
+++ b/src/services/images/getImageDefs.ts
@@ -31,7 +31,7 @@ const getSuffix = (y: string) => {
   return matches ? matches[1] : '';
 };
 
-const parsePathTag = (pathString?: string): PathType | undefined => {
+export const parsePathTag = (pathString?: string): PathType | undefined => {
   const points = pathString
     ?.split('|')
     .map((coords) => coords.split(',', 2))


### PR DESCRIPTION
### Description

The photo previews in the edit dialog now draw the same route lines as `FeatureImages` does in the feature panel — the edited item's own `…:path` tag plus the paths its members drew on that photo. Photos are matched by file name, tolerant to `_` vs. space and to the `File:` prefix.

**Live reaction to EditItems.** `useWikimediaCommonsPhotoPaths` reads the paths from the live `EditContext` items, so the shapes follow whatever is being edited: retargeting a slot to another photo, editing a member's `…:path` tag, or marking a member for deletion. Members not loaded into the dialog yet fall back to the `memberFeatures` already fetched for the feature panel, so the lines are visible right after opening instead of only after *Open all* — and once a member is loaded, the item wins, so nothing is drawn twice.

**Alignment.** Whenever something is drawn on a thumb, it is letterboxed (ratio measured from `naturalWidth/naturalHeight` on load) instead of cropped with `object-fit: cover` — otherwise the relative path coordinates would sit on the crop rather than on the photo. Thumbs without paths keep the previous cropped look.

**Refactor.** `PathsSvg` now renders `Path` from plain tags instead of a whole `Feature` (the grade colour only ever needed tags) and exports `PathsOverlaySvg`, so the edit dialog reuses the very same rendering. `Paths` used by `/api/og-image` is unchanged in behaviour. `parsePathTag` is newly exported from `getImageDefs`.

Not covered: highlighting a single path (`isHighlighted`). There is no hover/preview of a route inside the edit dialog, so all lines render in their difficulty colour; the prop is wired through for later.

### Example links

- https://openclimbing.org/relation/21241589/edit — *Hlavní lom*, 5 photos, 44 member routes all with `:path` tags

### Checklist

- [x] dark mode / light mode — colours come from the theme (`getDifficultyColor(…, palette.mode)` and `palette.getContrastText`), same as the feature panel
- [x] mobile / desktop — the thumb keeps its fixed box, the row layout is untouched
- [x] server-side-rendering (SSR) — the overlay only appears after the image reports its ratio in the browser; nothing new runs on the server
- [x] all texts are localized (in vocabulary.ts) — no new texts

### Verification

- New unit test `wikimediaCommonsPhotoPaths.test.ts` (5 cases); full suite 205/205, `tsc` and `next lint` clean.
- Driven in a real browser against `relation/21241589/edit` (OSM API served from production data, photos stubbed because `upload.wikimedia.org` is unreachable from the test environment): 5 lines on photo (2) immediately after opening, still 5 after *Open all* loaded all 45 items (no duplicates), and 19 lines after retargeting the slot to `File:Tomáškův lom - Korno (5).jpeg` — i.e. it re-renders live from the edited tags. The stub was a checkerboard, whose squares stayed square, confirming the letterboxing.