### PR TITLE
FeaturedLinkChips: use Wikipedia icon instead of globe

### DIFF
--- a/src/components/FeaturePanel/FeaturedLinkChips.tsx
+++ b/src/components/FeaturePanel/FeaturedLinkChips.tsx
@@ -1,7 +1,8 @@
 import Language from '@mui/icons-material/Language';
 import LocalPhone from '@mui/icons-material/LocalPhone';
-import { Chip } from '@mui/material';
+import { Chip, SvgIcon } from '@mui/material';
 import styled from '@emotion/styled';
+import { WikipediaIcon } from '../../assets/WikipediaIcon';
 import { PROJECT_ID } from '../../services/project';
 import { FeaturedKeyRenderer } from '../../services/tagging/featuredKeys';
 import { displayForm, protocol } from './renderers/helpers';
@@ -41,7 +42,9 @@ const iconForRenderer = (renderer: FeaturedKeyRenderer) => {
   if (renderer === 'WebsiteRenderer') return <Language fontSize="small" />;
   if (renderer === 'PhoneRenderer') return <LocalPhone fontSize="small" />;
   if (renderer === 'WikipediaRenderer' || renderer === 'WikidataRenderer') {
-    return <Language fontSize="small" />;
+    return (
+      <SvgIcon component={WikipediaIcon} inheritViewBox fontSize="small" />
+    );
   }
   return undefined;
 };


### PR DESCRIPTION
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EpKQTKkgVLJkf3jx8UkxaK