### PR TITLE
climbingTiles: add all via_ferrata

### DIFF
--- a/src/components/Map/climbingTiles/climbingLayers/climbingLayers.ts
+++ b/src/components/Map/climbingTiles/climbingLayers/climbingLayers.ts
@@ -1,5 +1,6 @@
 import { LayerSpecification } from '@maplibre/maplibre-gl-style-spec';
 import { routesLines } from './routesLines';
+import { ferrataLines } from './ferrataLines';
 import { ferrataLayer, groupsLayer, gymsLayer } from './groupsLayer';
 import { routesPoints } from './routesPoints';
 import { outlinesLayer } from './outlinesLayer';
@@ -7,6 +8,7 @@ import { outlinesLayer } from './outlinesLayer';
 export const climbingLayers: LayerSpecification[] = [
   outlinesLayer,
   ...routesLines,
+  ...ferrataLines,
   ...routesPoints,
   gymsLayer,
   ferrataLayer,

--- a/src/components/Map/climbingTiles/climbingLayers/ferrataLines.ts
+++ b/src/components/Map/climbingTiles/climbingLayers/ferrataLines.ts
@@ -1,0 +1,51 @@
+import { LayerSpecification } from '@maplibre/maplibre-gl-style-spec';
+import { CLIMBING_TILES_SOURCE, VIA_FERRATA } from '../consts';
+
+export const ferrataLines: LayerSpecification[] = [
+  {
+    id: 'climbing via_ferrata (line) - casing',
+    metadata: { clickableWithOsmId: true },
+    type: 'line',
+    source: CLIMBING_TILES_SOURCE,
+    minzoom: 13,
+    filter: ['==', 'type', 'ferrata'],
+    layout: { 'line-cap': 'round' },
+    paint: {
+      'line-color': '#f8f4f0',
+      'line-width': 4,
+    },
+  },
+  {
+    id: 'climbing via_ferrata (line)',
+    metadata: { clickableWithOsmId: true },
+    type: 'line',
+    source: CLIMBING_TILES_SOURCE,
+    minzoom: 13,
+    filter: ['==', 'type', 'ferrata'],
+    layout: { 'line-cap': 'round' },
+    paint: {
+      'line-color': VIA_FERRATA.COLOR,
+      'line-width': 2,
+      'line-dasharray': [2, 1],
+    },
+  },
+  {
+    id: 'climbing via_ferrata (line) - hover',
+    metadata: { clickableWithOsmId: true },
+    type: 'line',
+    source: CLIMBING_TILES_SOURCE,
+    minzoom: 13,
+    filter: ['==', 'type', 'ferrata'],
+    layout: { 'line-cap': 'round' },
+    paint: {
+      'line-color': '#000',
+      'line-opacity': [
+        'case',
+        ['boolean', ['feature-state', 'hover'], false],
+        1,
+        0,
+      ],
+      'line-width': 2,
+    },
+  },
+];

--- a/src/locales/cs.js
+++ b/src/locales/cs.js
@@ -917,7 +917,7 @@ export default {
   'osmtype.way.description': 'Linie se skládá z dalších uzlů (node).',
   'osmtype.relation': 'Relace',
   'osmtype.relation.description': 'Skupina dalších prvků – cest, uzlů a případně dalších relací.',
-  'climbing_tiles.stats': `Obnovuje se: cca 1× / měsíc (<a href="https://community.openstreetmap.org/t/overpass-api-performance-issues/140598">dokud nejsou vyřešeny problémy s Overpass</a>)<br />Naposledy: __lastRefresh__<br />OSM timestamp: __osmTime__<br/>CDN cache: 1 hodina`,
+  'climbing_tiles.stats': `Obnovuje se: průběžně (minutová replikace OSM)<br />Naposledy: __lastRefresh__<br />OSM timestamp: __osmTime__<br/>CDN cache: 1 hodina`,
   'climbing.type.ferrata': 'Via Ferrata',
   'climbing.forum': 'Diskusní fórum',
 

--- a/src/locales/cs.js
+++ b/src/locales/cs.js
@@ -917,7 +917,7 @@ export default {
   'osmtype.way.description': 'Linie se skládá z dalších uzlů (node).',
   'osmtype.relation': 'Relace',
   'osmtype.relation.description': 'Skupina dalších prvků – cest, uzlů a případně dalších relací.',
-  'climbing_tiles.stats': `Obnovuje se: průběžně (minutová replikace OSM)<br />Naposledy: __lastRefresh__<br />OSM timestamp: __osmTime__<br/>CDN cache: 1 hodina`,
+  'climbing_tiles.stats': `Obnovuje se: průběžně (<a href="https://github.com/zbycz/openclimbing-minutely-replication" target="_blank">minutová replikace OSM</a>)<br />Naposledy: __lastRefresh__<br />OSM timestamp: __osmTime__<br/>CDN cache: 1 minuta`,
   'climbing.type.ferrata': 'Via Ferrata',
   'climbing.forum': 'Diskusní fórum',
 

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -981,7 +981,7 @@ export default {
   'osmtype.way.description': 'Line consisting of severel (many) nodes.',
   'osmtype.relation': 'Relation',
   'osmtype.relation.description': 'Group of other elements – ways, nodes, and even other relations.',
-  'climbing_tiles.stats': `Refreshed: continuously (minutely OSM replication)<br />Last refresh: __lastRefresh__<br />OSM timestamp: __osmTime__<br/>CDN cache: 1 hour`,
+  'climbing_tiles.stats': `Refreshed: continuously (<a href="https://github.com/zbycz/openclimbing-minutely-replication" target="_blank">minutely OSM replication</a>)<br />Last refresh: __lastRefresh__<br />OSM timestamp: __osmTime__<br/>CDN cache: 1 minute`,
   'climbing.type.ferrata': 'Via Ferrata',
   'climbing.forum': 'Community board',
 

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -981,7 +981,7 @@ export default {
   'osmtype.way.description': 'Line consisting of severel (many) nodes.',
   'osmtype.relation': 'Relation',
   'osmtype.relation.description': 'Group of other elements – ways, nodes, and even other relations.',
-  'climbing_tiles.stats': `Refreshed: ~1× / month (<a href="https://community.openstreetmap.org/t/overpass-api-performance-issues/140598">until overpass issues are resolved</a>)<br />Last refresh: __lastRefresh__<br />OSM timestamp: __osmTime__<br/>CDN cache: 1 hour`,
+  'climbing_tiles.stats': `Refreshed: continuously (minutely OSM replication)<br />Last refresh: __lastRefresh__<br />OSM timestamp: __osmTime__<br/>CDN cache: 1 hour`,
   'climbing.type.ferrata': 'Via Ferrata',
   'climbing.forum': 'Community board',
 

--- a/src/server/climbing-tiles/README.md
+++ b/src/server/climbing-tiles/README.md
@@ -33,7 +33,7 @@ We serve ~1000 tile requests/day, server cache HITS are ~1ms, MISSes ~12ms.
 
 `/api/climbing-tiles/refresh`:
 
-- download overpass query – all `climbing=*` or `sport=climbing` elements and all relation members
+- download overpass query – all `climbing*=*`, `sport=climbing` and via ferrata elements (same filter as the [osmium seed](https://github.com/zbycz/openclimbing-osmium-import) and the [minutely replication](https://github.com/zbycz/openclimbing-minutely-replication/blob/main/src/utils/filter.ts)) and all relation members
 - contruct full geometries from OSM elements - `overpassToGeojsons()`
 - filter only relevant data + create SQL records (each record also stores the raw OSM `tags` as JSON, and for relations the `members` array as JSON)
 - insert the records them in `climbing_features` table

--- a/src/server/climbing-tiles/__tests__/refreshClimbingTiles_ferrata.test.ts
+++ b/src/server/climbing-tiles/__tests__/refreshClimbingTiles_ferrata.test.ts
@@ -1,0 +1,65 @@
+import { OsmResponse } from '../overpass/types';
+import { getNewRecords } from '../refreshClimbingTiles';
+
+jest.mock('../../db/db', () => ({ getDb: () => undefined }));
+jest.mock('next-codegrid', () => ({ resolveCountryCode: jest.fn() }));
+
+const response: OsmResponse = {
+  osm3s: { timestamp_osm_base: 'string' },
+  elements: [
+    {
+      type: 'node',
+      id: 10,
+      lat: 49.04,
+      lon: 11.97,
+      tags: {
+        natural: 'cliff',
+        sport: 'via_ferrata',
+        via_ferrata: 'start',
+        name: 'Via Ferrata du Belvédère',
+      },
+    },
+    { type: 'node', id: 1, lat: 49.1, lon: 11.9 },
+    { type: 'node', id: 2, lat: 49.2, lon: 11.8 },
+    {
+      type: 'way',
+      id: 3,
+      nodes: [1, 2],
+      tags: { highway: 'path', via_ferrata_scale: '2+', name: 'Nordwandsteig' },
+    },
+    { type: 'node', id: 4, lat: 49.3, lon: 11.7 },
+    { type: 'node', id: 5, lat: 49.4, lon: 11.6 },
+    {
+      type: 'way',
+      id: 6,
+      nodes: [4, 5],
+      tags: { highway: 'via_ferrata' },
+    },
+    {
+      type: 'relation',
+      id: 7,
+      members: [{ type: 'way', ref: 6, role: '' }],
+      tags: { route: 'via_ferrata', name: 'Klettersteig' },
+    },
+    {
+      type: 'relation',
+      id: 8,
+      members: [{ type: 'way', ref: 3, role: '' }],
+      tags: { sport: 'via_ferrata', name: 'Ferrata delle Taccole' },
+    },
+  ],
+};
+
+describe('getNewRecords', () => {
+  it('keeps all via ferrata elements from the osmium filter', () => {
+    const records = getNewRecords(response, () => {});
+
+    expect(records.map(({ type, osmType }) => `${osmType}:${type}`)).toEqual([
+      'node:ferrata',
+      'way:route',
+      'way:route',
+      'relation:ferrata',
+      'relation:ferrata',
+    ]);
+  });
+});

--- a/src/server/climbing-tiles/__tests__/refreshClimbingTiles_ferrata.test.ts
+++ b/src/server/climbing-tiles/__tests__/refreshClimbingTiles_ferrata.test.ts
@@ -56,8 +56,8 @@ describe('getNewRecords', () => {
 
     expect(records.map(({ type, osmType }) => `${osmType}:${type}`)).toEqual([
       'node:ferrata',
-      'way:route',
-      'way:route',
+      'way:ferrata',
+      'way:ferrata',
       'relation:ferrata',
       'relation:ferrata',
     ]);

--- a/src/server/climbing-tiles/buildTileGeojson.ts
+++ b/src/server/climbing-tiles/buildTileGeojson.ts
@@ -145,13 +145,17 @@ export const getProperties = (
   return undefined;
 };
 
-const buildGeojson = (record: ClimbingFeaturesRow): ClimbingTilesFeature => {
+const buildGeojson = (
+  record: ClimbingFeaturesRow,
+  withLines: boolean,
+): ClimbingTilesFeature => {
   const { osmType, osmId, line, lon, lat } = record;
   const id = convertOsmIdToMapId({ type: osmType, id: osmId });
   const properties = getProperties(record);
-  const geometry: Geometry = line
-    ? { type: 'LineString', coordinates: JSON.parse(line) }
-    : { type: 'Point', coordinates: [lon, lat] };
+  const geometry: Geometry =
+    line && withLines
+      ? { type: 'LineString', coordinates: JSON.parse(line) }
+      : { type: 'Point', coordinates: [lon, lat] };
 
   return { type: 'Feature', id, geometry, properties };
 };
@@ -190,7 +194,11 @@ export const buildTileGeojson = (
   recordsInBbox: ClimbingFeaturesRow[],
   bbox: BBox,
 ): GeoJSON.FeatureCollection => {
-  const featuresInBbox = recordsInBbox.map(buildGeojson);
+  // ferratas skip the grid, so in the world/z6 tiles their lines would be sent
+  // whole - the center point is enough for the icon there
+  const featuresInBbox = recordsInBbox.map((record) =>
+    buildGeojson(record, !isOptimizedToGrid),
+  );
 
   let features: ClimbingTilesFeature[];
   if (isOptimizedToGrid) {

--- a/src/server/climbing-tiles/refreshClimbingTiles.ts
+++ b/src/server/climbing-tiles/refreshClimbingTiles.ts
@@ -24,7 +24,7 @@ const fetchFromOverpass = async () => {
   }
 
   // takes about 42 secs, 25MB; in May25 = 25MB - 217k items->55k records
-  // sync this with openclimbing-osmium-import/02_extract_climbing_osmium.sh 
+  // sync this with openclimbing-osmium-import/02_extract_climbing_osmium.sh
   //              + openclimbing-minutely-replication/src/utils/filter.ts
   const query = `[out:json][timeout:100];(nwr[~"^climbing"~"."];nwr["sport"="climbing"];nwr["sport"="via_ferrata"];nwr["highway"="via_ferrata"];nwr["route"="via_ferrata"];nwr["via_ferrata_scale"];);(._;>>;);out qt;`;
   const data = await fetchOverpass(query, { nocache: true });

--- a/src/server/climbing-tiles/refreshClimbingTiles.ts
+++ b/src/server/climbing-tiles/refreshClimbingTiles.ts
@@ -21,7 +21,10 @@ const fetchFromOverpass = async () => {
   }
 
   // takes about 42 secs, 25MB; in May25 = 25MB - 217k items->55k records
-  const query = `[out:json][timeout:100];(nwr["climbing"];nwr["sport"="climbing"];);(._;>>;);out qt;`; // TODO add + test speed: nwr["sport"="via_ferrata"];nwr[~"^climbing"~".*"];
+  // Keep in sync with the osmium seed (openclimbing-osmium-import `osmium tags-filter`)
+  // and the minutely replication filter:
+  // https://github.com/zbycz/openclimbing-minutely-replication/blob/main/src/utils/filter.ts
+  const query = `[out:json][timeout:100];(nwr[~"^climbing"~"."];nwr["sport"="climbing"];nwr["sport"="via_ferrata"];nwr["highway"="via_ferrata"];nwr["route"="via_ferrata"];nwr["via_ferrata_scale"];);(._;>>;);out qt;`;
   const data = await fetchOverpass(query, { nocache: true });
 
   if (data.elements.length < 1000) {

--- a/src/server/climbing-tiles/refreshClimbingTiles.ts
+++ b/src/server/climbing-tiles/refreshClimbingTiles.ts
@@ -46,6 +46,12 @@ const ROUTE_VALUES = ['route', 'route_bottom', 'abseil_route'];
 
 const isRoute = (tags: FeatureTags) => ROUTE_VALUES.includes(tags.climbing);
 
+const isFerrata = (tags: FeatureTags) =>
+  tags.highway === 'via_ferrata' ||
+  tags.route === 'via_ferrata' ||
+  tags.sport === 'via_ferrata' ||
+  !!tags.via_ferrata_scale;
+
 // (splitting this function doesn't make sense - it has very simple structure)
 // eslint-disable-next-line max-lines-per-function
 export const getNewRecords = (
@@ -90,6 +96,11 @@ export const getNewRecords = (
       continue;
     }
 
+    // usually natural=cliff + sport=via_ferrata + via_ferrata=start
+    else if (isFerrata(node.tags)) {
+      addRecord('ferrata', node);
+    }
+
     // careful, this has to omit `shop=sports` etc.
     else if (node.tags.sport === 'climbing') {
       if (node.tags.man_made || node.tags.name?.match(/gym/i)) {
@@ -109,7 +120,7 @@ export const getNewRecords = (
     if (!way.tags || isClimbingDisallowed(way.tags)) continue;
 
     //
-    if (isRoute(way.tags) || way.tags.highway === 'via_ferrata') {
+    if (isRoute(way.tags) || isFerrata(way.tags)) {
       addRecordWithLine('route', way);
     }
 
@@ -144,10 +155,7 @@ export const getNewRecords = (
     if (!relation.tags || isClimbingDisallowed(relation.tags)) continue;
 
     // usually climbing=route + route=via_ferrata
-    if (
-      relation.tags.route === 'via_ferrata' ||
-      relation.tags.via_ferrata_scale
-    ) {
+    if (isFerrata(relation.tags)) {
       addRecord('ferrata', centerGeometry(relation));
     }
 

--- a/src/server/climbing-tiles/refreshClimbingTiles.ts
+++ b/src/server/climbing-tiles/refreshClimbingTiles.ts
@@ -14,6 +14,9 @@ import { FeatureTags } from '../../services/types';
 import { ClimbingFeaturesRow } from '../db/types';
 import { resolveCountryCode } from 'next-codegrid';
 
+// Overpass is a fallback. On production we use:
+// - https://github.com/zbycz/openclimbing-osmium-import
+// - https://github.com/zbycz/openclimbing-minutely-replication
 const fetchFromOverpass = async () => {
   if (existsSync('../overpass.json')) {
     console.log('fetchFromOverpass: Using cache in ../overpass.json'); //eslint-disable-line no-console
@@ -21,9 +24,8 @@ const fetchFromOverpass = async () => {
   }
 
   // takes about 42 secs, 25MB; in May25 = 25MB - 217k items->55k records
-  // Keep in sync with the osmium seed (openclimbing-osmium-import `osmium tags-filter`)
-  // and the minutely replication filter:
-  // https://github.com/zbycz/openclimbing-minutely-replication/blob/main/src/utils/filter.ts
+  // sync this with openclimbing-osmium-import/02_extract_climbing_osmium.sh 
+  //              + openclimbing-minutely-replication/src/utils/filter.ts
   const query = `[out:json][timeout:100];(nwr[~"^climbing"~"."];nwr["sport"="climbing"];nwr["sport"="via_ferrata"];nwr["highway"="via_ferrata"];nwr["route"="via_ferrata"];nwr["via_ferrata_scale"];);(._;>>;);out qt;`;
   const data = await fetchOverpass(query, { nocache: true });
 

--- a/src/server/climbing-tiles/refreshClimbingTiles.ts
+++ b/src/server/climbing-tiles/refreshClimbingTiles.ts
@@ -120,8 +120,13 @@ export const getNewRecords = (
     if (!way.tags || isClimbingDisallowed(way.tags)) continue;
 
     //
-    if (isRoute(way.tags) || isFerrata(way.tags)) {
+    if (isRoute(way.tags)) {
       addRecordWithLine('route', way);
+    }
+
+    //
+    else if (isFerrata(way.tags)) {
+      addRecordWithLine('ferrata', way);
     }
 
     //


### PR DESCRIPTION
They were missing, because our data seed was only `sport=via_ferrata`, added higway=via_ferrata and route=via_ferrata.

It will need more tweaking for proper display of relations.


# Data pipeline:

1) https://github.com/zbycz/openclimbing-osmium-import/commit/622d5350255e438cba6519bd75723989ebe1331a
```
osmium tags-filter \
        "$PLANET_FILE" \
        'nwr/climbing*' \
        nwr/sport=climbing \
        nwr/sport=via_ferrata \
        nwr/highway=via_ferrata \
        nwr/route=via_ferrata \
        nwr/via_ferrata_scale \
        --overwrite \
        --progress \
        -o filtered.osm.pbf
```


2) https://github.com/zbycz/openclimbing-minutely-replication/pull/2

3) this