### PR TITLE
climbingTiles: require climbing context for peak/leisure/site rules

### DIFF
--- a/src/server/climbing-tiles/__tests__/refreshClimbingTiles_geometryOnly.test.ts
+++ b/src/server/climbing-tiles/__tests__/refreshClimbingTiles_geometryOnly.test.ts
@@ -1,0 +1,119 @@
+import { OsmResponse } from '../overpass/types';
+import { getNewRecords } from '../refreshClimbingTiles';
+
+jest.mock('../../db/db', () => ({ getDb: () => undefined }));
+jest.mock('next-codegrid', () => ({ resolveCountryCode: jest.fn() }));
+
+const getTypes = (response: OsmResponse) =>
+  getNewRecords(response, () => {}).map(
+    ({ osmType, osmId, type }) => `${osmType}/${osmId}:${type}`,
+  );
+
+describe('getNewRecords - elements without own climbing tags', () => {
+  it('skips natural=peak which is only a geometry node of a climbing* way', () => {
+    const response: OsmResponse = {
+      osm3s: { timestamp_osm_base: '' },
+      elements: [
+        {
+          type: 'node',
+          id: 1499407286,
+          lat: 47.2956865,
+          lon: 11.3434741,
+          tags: { natural: 'peak', name: 'Brandjochkreuz', ele: '2268' },
+        },
+        { type: 'node', id: 2, lat: 47.29, lon: 11.34 },
+        {
+          type: 'way',
+          id: 136666845,
+          nodes: [1499407286, 2],
+          tags: { highway: 'path', 'climbing:grade:uiaa': '3' },
+        },
+      ],
+    };
+
+    expect(getTypes(response)).toEqual([]);
+  });
+
+  it('keeps natural=peak which is a member of a climbing relation', () => {
+    const response: OsmResponse = {
+      osm3s: { timestamp_osm_base: '' },
+      elements: [
+        {
+          type: 'node',
+          id: 1499407286,
+          lat: 47.2956865,
+          lon: 11.3434741,
+          tags: { natural: 'peak', name: 'Brandjochkreuz' },
+        },
+        {
+          type: 'relation',
+          id: 10,
+          members: [{ type: 'node', ref: 1499407286, role: '' }],
+          tags: { climbing: 'area', name: 'Area' },
+        },
+      ],
+    };
+
+    expect(getTypes(response)).toEqual([
+      'node/1499407286:crag',
+      'relation/10:area',
+    ]);
+  });
+
+  it('keeps natural=peak tagged with climbing itself', () => {
+    const response: OsmResponse = {
+      osm3s: { timestamp_osm_base: '' },
+      elements: [
+        {
+          type: 'node',
+          id: 3,
+          lat: 47.29,
+          lon: 11.34,
+          tags: { natural: 'peak', 'climbing:sport': '5' },
+        },
+      ],
+    };
+
+    expect(getTypes(response)).toEqual(['node/3:crag']);
+  });
+
+  it('skips a building which is only a member of a non-climbing relation', () => {
+    const response: OsmResponse = {
+      osm3s: { timestamp_osm_base: '' },
+      elements: [
+        {
+          type: 'node',
+          id: 4,
+          lat: 47.29,
+          lon: 11.34,
+          tags: { building: 'yes', name: 'Hut' },
+        },
+        {
+          type: 'relation',
+          id: 11,
+          members: [{ type: 'node', ref: 4, role: '' }],
+          tags: { type: 'mountain_range' },
+        },
+      ],
+    };
+
+    expect(getTypes(response)).toEqual([]);
+  });
+
+  it('keeps a gym with leisure + sport=climbing', () => {
+    const response: OsmResponse = {
+      osm3s: { timestamp_osm_base: '' },
+      elements: [
+        {
+          type: 'node',
+          id: 5,
+          lat: 47.29,
+          lon: 11.34,
+          tags: { leisure: 'sports_centre', sport: 'climbing', name: 'Gym' },
+        },
+      ],
+    };
+
+    expect(getTypes(response)).toEqual(['node/5:gym']);
+  });
+});

--- a/src/server/climbing-tiles/refreshClimbingTiles.ts
+++ b/src/server/climbing-tiles/refreshClimbingTiles.ts
@@ -9,7 +9,7 @@ import {
   recordsFactory,
 } from './refreshClimbingTilesHelpers';
 import { cacheTile000 } from './getClimbingTile';
-import { OsmResponse } from './overpass/types';
+import { GeojsonFeature, OsmResponse } from './overpass/types';
 import { FeatureTags } from '../../services/types';
 import { ClimbingFeaturesRow } from '../db/types';
 import { resolveCountryCode } from 'next-codegrid';
@@ -52,6 +52,38 @@ const isFerrata = (tags: FeatureTags) =>
   tags.sport === 'via_ferrata' ||
   !!tags.via_ferrata_scale;
 
+// same condition as the osmium tags-filter which builds ../overpass.json
+const hasClimbingTags = (tags: FeatureTags) =>
+  tags.sport === 'climbing' ||
+  tags.leisure === 'climbing' ||
+  isFerrata(tags) ||
+  Object.keys(tags).some((key) => key.startsWith('climbing'));
+
+const getClimbingRelationMemberIds = (relations: GeojsonFeature[]) => {
+  const memberIds = new Set<string>();
+  for (const relation of relations) {
+    if (!relation.tags || isClimbingDisallowed(relation.tags)) continue;
+    if (!hasClimbingTags(relation.tags)) continue;
+
+    for (const member of relation.members ?? []) {
+      memberIds.add(`${member.type}/${member.ref}`);
+    }
+  }
+  return memberIds;
+};
+
+// The dataset contains also elements with no climbing tag at all - nodes forming
+// the geometry of a matched way and members of matched relations. Rules which
+// don't test a climbing tag (natural=peak, leisure, building, type=site) must
+// not pick those up - eg. node/1499407286 natural=peak is only a geometry node
+// of a highway=path tagged climbing:grade:uiaa.
+const isClimbingRelatedFactory =
+  (climbingRelationMemberIds: Set<string>) => (feature: GeojsonFeature) =>
+    hasClimbingTags(feature.tags) ||
+    climbingRelationMemberIds.has(
+      `${feature.osmMeta.type}/${feature.osmMeta.id}`,
+    );
+
 // (splitting this function doesn't make sense - it has very simple structure)
 // eslint-disable-next-line max-lines-per-function
 export const getNewRecords = (
@@ -60,6 +92,9 @@ export const getNewRecords = (
 ) => {
   const geojsons = overpassToGeojsons(data, log); // 300 ms on 200k items
   const { records, addRecord, addRecordWithLine } = recordsFactory(log);
+  const isClimbingRelated = isClimbingRelatedFactory(
+    getClimbingRelationMemberIds(geojsons.relation),
+  );
 
   for (const node of geojsons.node) {
     if (!node.tags || isClimbingDisallowed(node.tags)) continue;
@@ -71,7 +106,7 @@ export const getNewRecords = (
     else if (
       node.tags.climbing === 'crag' ||
       node.tags.climbing === 'boulder' ||
-      node.tags.natural === 'peak'
+      (node.tags.natural === 'peak' && isClimbingRelated(node))
     ) {
       addRecord('crag', node);
     }
@@ -87,7 +122,10 @@ export const getNewRecords = (
     }
 
     //
-    else if (node.tags.leisure || node.tags.building) {
+    else if (
+      (node.tags.leisure || node.tags.building) &&
+      isClimbingRelated(node)
+    ) {
       addRecord('gym', node);
     }
 
@@ -130,7 +168,10 @@ export const getNewRecords = (
     }
 
     //
-    else if (way.tags.leisure || way.tags.building) {
+    else if (
+      (way.tags.leisure || way.tags.building) &&
+      isClimbingRelated(way)
+    ) {
       addRecord('gym', centerGeometry(way));
     }
 
@@ -170,7 +211,10 @@ export const getNewRecords = (
     }
 
     // usually a type=multipolygon relation
-    else if (relation.tags.leisure || relation.tags.building) {
+    else if (
+      (relation.tags.leisure || relation.tags.building) &&
+      isClimbingRelated(relation)
+    ) {
       addRecord('gym', centerGeometry(relation));
     }
 
@@ -183,8 +227,9 @@ export const getNewRecords = (
     else if (
       relation.tags.climbing ||
       relation.tags.sport === 'climbing' ||
-      relation.tags.type === 'site' ||
-      relation.tags.type === 'multipolygon'
+      ((relation.tags.type === 'site' ||
+        relation.tags.type === 'multipolygon') &&
+        isClimbingRelated(relation))
     ) {
       addRecord('crag', centerGeometry(relation));
     }


### PR DESCRIPTION
The dataset contains also elements with no climbing tag - geometry nodes of matched ways and members of matched relations. eg. node/1499407286 natural=peak was shown as a crag, being just a node of a highway=path with climbing:grade:uiaa.

https://openclimbing.org/node/1499407286
https://www.openstreetmap.org/node/1499407286


Claude-Session: https://claude.ai/code/session_01F5TELeUscqrGY7hFW6X7ur
