### PR TITLE
GradeSystemSelect: group grade systems by climbing style

### DIFF
--- a/src/components/FeaturePanel/Climbing/ClimbingPdfExportDialog.tsx
+++ b/src/components/FeaturePanel/Climbing/ClimbingPdfExportDialog.tsx
@@ -1551,7 +1551,7 @@ export const ClimbingPdfExportDialog = ({ isOpen, onClose }: Props) => {
           </MenuItem>
           <MenuItem disableRipple sx={{ cursor: 'default', gap: 1 }}>
             <ListItemText primary={t('user_settings.default_grade_system')} />
-            <GradeSystemSelect />
+            <GradeSystemSelect orderByFeature />
           </MenuItem>
         </Menu>
         <Button

--- a/src/components/FeaturePanel/Climbing/GradeSystemSelect.tsx
+++ b/src/components/FeaturePanel/Climbing/GradeSystemSelect.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import styled from '@emotion/styled';
 import ViewListIcon from '@mui/icons-material/ViewList';
 import { Button, Stack, Tooltip } from '@mui/material';
 import { alpha } from '@mui/material/styles';
@@ -23,6 +24,27 @@ import {
   FilterOption,
   FilterSectionLabel,
 } from './Filter/filterUi';
+import { tint } from '../../utils/panelUi';
+
+// own wrapper per category, so each heading is pushed out by the next section
+const CategorySection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;
+
+// opaque, so options scrolling underneath don't show through the pinned heading
+const CategoryLabel = styled(FilterSectionLabel)`
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding: 6px 0 4px;
+  background-color: ${({ theme }) => theme.palette.background.paper};
+  background-image: linear-gradient(
+    ${({ theme }) => tint(theme, 0.045)},
+    ${({ theme }) => tint(theme, 0.045)}
+  );
+`;
 
 const GradeSystemCategories = ({
   showMore,
@@ -54,10 +76,10 @@ const GradeSystemCategories = ({
   return (
     <>
       {categories.map(({ key: categoryKey, label, gradeSystems }, index) => (
-        <React.Fragment key={categoryKey}>
-          <FilterSectionLabel $flush style={{ marginTop: index ? 8 : 4 }}>
+        <CategorySection key={categoryKey}>
+          <CategoryLabel $flush style={{ marginTop: index ? 8 : 0 }}>
             {t(label)}
-          </FilterSectionLabel>
+          </CategoryLabel>
           {gradeSystems.map(({ key, name, description, flags }) => (
             <Tooltip
               title={description}
@@ -76,7 +98,7 @@ const GradeSystemCategories = ({
               </FilterOption>
             </Tooltip>
           ))}
-        </React.Fragment>
+        </CategorySection>
       ))}
     </>
   );

--- a/src/components/FeaturePanel/Climbing/GradeSystemSelect.tsx
+++ b/src/components/FeaturePanel/Climbing/GradeSystemSelect.tsx
@@ -4,6 +4,7 @@ import { Button, Stack, Tooltip } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import {
   DEFAULT_GRADE_SYSTEM,
+  getGradeSystemCategoriesForTags,
   getGradeSystemName,
   GRADE_SYSTEMS,
   GradeSystem,
@@ -14,44 +15,68 @@ import { t } from '../../../services/intl';
 import { ClimbingGradesTable } from './ClimbingGradesTable/ClimbingGradesTable';
 import { useVisibleGradeSystems } from './utils/useVisibleGradeSystems';
 import { useUserSettingsContext } from '../../utils/userSettings/UserSettingsContext';
+import { useFeatureContext } from '../../utils/FeatureContext';
 import { GLASS_PAPER_SX, PopperWithArrow } from '../../utils/PopperWithArrow';
-import { FilterBody, FilterCard, FilterOption } from './Filter/filterUi';
+import {
+  FilterBody,
+  FilterCard,
+  FilterOption,
+  FilterSectionLabel,
+} from './Filter/filterUi';
 
-const GradeSystemItems = ({
-  showMinor,
+const GradeSystemCategories = ({
+  showMore,
   onClick,
   selectedGradeSystem,
+  orderByFeature,
 }: {
-  showMinor: boolean;
+  showMore: boolean;
   onClick: (key: GradeSystem) => void;
   selectedGradeSystem: GradeSystem | undefined;
+  orderByFeature?: boolean;
 }) => {
   const visibleGradeSystems = useVisibleGradeSystems();
+  const { feature } = useFeatureContext();
 
-  const filteredGradeSystems = GRADE_SYSTEMS.filter(({ key }) =>
-    showMinor
-      ? !visibleGradeSystems.includes(key)
-      : visibleGradeSystems.includes(key),
-  );
+  const categories = getGradeSystemCategoriesForTags(
+    orderByFeature ? feature?.tags : undefined,
+  )
+    .map((category) => ({
+      ...category,
+      gradeSystems: GRADE_SYSTEMS.filter(
+        ({ key, category: gradeSystemCategory }) =>
+          gradeSystemCategory === category.key &&
+          (showMore || visibleGradeSystems.includes(key)),
+      ),
+    }))
+    .filter(({ gradeSystems }) => gradeSystems.length);
+
   return (
     <>
-      {filteredGradeSystems.map(({ key, name, description, flags }) => (
-        <Tooltip
-          title={description}
-          placement="right"
-          enterDelay={1000}
-          arrow
-          key={key}
-        >
-          <FilterOption
-            type="button"
-            $selected={selectedGradeSystem === key}
-            onClick={() => onClick(key)}
-          >
-            <span>{name}</span>
-            <span>{flags}</span>
-          </FilterOption>
-        </Tooltip>
+      {categories.map(({ key: categoryKey, label, gradeSystems }, index) => (
+        <React.Fragment key={categoryKey}>
+          <FilterSectionLabel $flush style={{ marginTop: index ? 8 : 4 }}>
+            {t(label)}
+          </FilterSectionLabel>
+          {gradeSystems.map(({ key, name, description, flags }) => (
+            <Tooltip
+              title={description}
+              placement="right"
+              enterDelay={1000}
+              arrow
+              key={key}
+            >
+              <FilterOption
+                type="button"
+                $selected={selectedGradeSystem === key}
+                onClick={() => onClick(key)}
+              >
+                <span>{name}</span>
+                <span>{flags}</span>
+              </FilterOption>
+            </Tooltip>
+          ))}
+        </React.Fragment>
       ))}
     </>
   );
@@ -61,12 +86,14 @@ type Props = {
   size?: 'small' | 'tiny';
   onGradeSystemChange?: (gradeSystem: GradeSystem) => void;
   showDefaultOnButton?: boolean;
+  orderByFeature?: boolean;
 };
 
 export const GradeSystemSelect = ({
   size,
   onGradeSystemChange,
   showDefaultOnButton,
+  orderByFeature,
 }: Props) => {
   const { userSettings, setUserSetting } = useUserSettingsContext();
   const [isGradeTableOpen, setIsGradeTableOpen] = useState(false);
@@ -143,18 +170,12 @@ export const GradeSystemSelect = ({
               >
                 {t('grade_system_select.default_grade_system')}
               </FilterOption>
-              <GradeSystemItems
-                showMinor={false}
+              <GradeSystemCategories
+                showMore={showMore}
                 onClick={changeGradeSystem}
                 selectedGradeSystem={selectedGradeSystem}
+                orderByFeature={orderByFeature}
               />
-              {showMore && (
-                <GradeSystemItems
-                  showMinor
-                  onClick={changeGradeSystem}
-                  selectedGradeSystem={selectedGradeSystem}
-                />
-              )}
             </Stack>
           </FilterCard>
           {!showMore && (

--- a/src/components/FeaturePanel/Climbing/RouteDistribution.tsx
+++ b/src/components/FeaturePanel/Climbing/RouteDistribution.tsx
@@ -396,7 +396,7 @@ const CompactChart = ({
 // ------------------------------------------------------------------- heading
 
 const DistributionLabel = () => (
-  <PanelLabel addition={<GradeSystemSelect size="tiny" />}>
+  <PanelLabel addition={<GradeSystemSelect orderByFeature size="tiny" />}>
     {t('featurepanel.grade_range')}
   </PanelLabel>
 );
@@ -449,7 +449,7 @@ export const RouteDistribution = ({
   // the untrimmed count, so a crag with a single grade still gets its chart
   if (allBuckets.length < 2) {
     return (
-      <PanelLabel addition={<GradeSystemSelect />}>
+      <PanelLabel addition={<GradeSystemSelect orderByFeature />}>
         {t('grade_system_select.convert_grade')}
       </PanelLabel>
     );
@@ -469,7 +469,7 @@ export const RouteDistribution = ({
                     gradeSystemName: getGradeSystemName(gradeSystem),
                   })}
                 >
-                  <GradeSystemSelect size="tiny" />
+                  <GradeSystemSelect orderByFeature size="tiny" />
                 </Tooltip>
               </GradeSystemName>
             )}

--- a/src/components/FeaturePanel/Climbing/RouteList/RouteListDndContent.tsx
+++ b/src/components/FeaturePanel/Climbing/RouteList/RouteListDndContent.tsx
@@ -119,7 +119,7 @@ export const RouteListDndContent = () => {
                 mr: 1,
               }}
             >
-              <GradeSystemSelect />
+              <GradeSystemSelect orderByFeature />
             </Box>
           </MaxWidthContainer>
         </TableHeader>
@@ -153,7 +153,7 @@ export const RouteListDndContent = () => {
       })}
       {isMobileMode && (
         <BottomGradeSystem>
-          <GradeSystemSelect />
+          <GradeSystemSelect orderByFeature />
         </BottomGradeSystem>
       )}
     </Container>

--- a/src/components/FeaturePanel/ClimbingRouteGrade.tsx
+++ b/src/components/FeaturePanel/ClimbingRouteGrade.tsx
@@ -23,7 +23,7 @@ export const ClimbingRouteGrade = () => {
       }}
     >
       <ConvertedRouteDifficultyBadge routeDifficulties={routeDifficulties} />
-      <GradeSystemSelect />
+      <GradeSystemSelect orderByFeature />
     </Stack>
   );
 };

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/AddMemberForm.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/AddMemberForm.tsx
@@ -310,7 +310,9 @@ const BatchTextarea = (props: { label: string; setLabel: Setter<string> }) => {
         placeholder={placeholder}
         onChange={(e) => props.setLabel(e.target.value)}
       />
-      {gradeSystem ? <GradeSystemSelect showDefaultOnButton /> : null}
+      {gradeSystem ? (
+        <GradeSystemSelect orderByFeature showDefaultOnButton />
+      ) : null}
     </>
   );
 };

--- a/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/ClimbingEditor/ClimbingGradesEditor.tsx
+++ b/src/components/FeaturePanel/EditDialog/EditContent/FeatureEditSection/ClimbingEditor/ClimbingGradesEditor.tsx
@@ -51,7 +51,7 @@ export const ClimbingGradesEditor = () => {
             tags={tags}
           />
         </Box>
-        <GradeSystemSelect showDefaultOnButton />
+        <GradeSystemSelect orderByFeature showDefaultOnButton />
       </Stack>
     </Box>
   );

--- a/src/locales/cs.js
+++ b/src/locales/cs.js
@@ -872,6 +872,7 @@ export default {
   'grade_system_select.convert_grade_short': 'Převést',
   'grade_system_select.convert_grade': 'Převést klasifikaci',
   'grade_system_select.select_grade_system': 'Vybrat klasifikaci',
+  'grade_system_select.category_roped': 'S lanem',
 
   'crag_sort.title': 'Seřadit',
   'crag_sort.option_default': 'Defaultní',

--- a/src/locales/cs.js
+++ b/src/locales/cs.js
@@ -872,7 +872,7 @@ export default {
   'grade_system_select.convert_grade_short': 'Převést',
   'grade_system_select.convert_grade': 'Převést klasifikaci',
   'grade_system_select.select_grade_system': 'Vybrat klasifikaci',
-  'grade_system_select.category_roped': 'S lanem',
+  'grade_system_select.category_routes': 'Cesty',
 
   'crag_sort.title': 'Seřadit',
   'crag_sort.option_default': 'Defaultní',

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -936,6 +936,7 @@ export default {
   'grade_system_select.convert_grade_short': 'Convert',
   'grade_system_select.convert_grade': 'Convert grades',
   'grade_system_select.select_grade_system': 'Select grade system',
+  'grade_system_select.category_roped': 'With rope',
 
   'crag_sort.title': 'Sort',
   'crag_sort.option_default': 'Default',

--- a/src/locales/vocabulary.js
+++ b/src/locales/vocabulary.js
@@ -936,7 +936,7 @@ export default {
   'grade_system_select.convert_grade_short': 'Convert',
   'grade_system_select.convert_grade': 'Convert grades',
   'grade_system_select.select_grade_system': 'Select grade system',
-  'grade_system_select.category_roped': 'With rope',
+  'grade_system_select.category_routes': 'Routes',
 
   'crag_sort.title': 'Sort',
   'crag_sort.option_default': 'Default',

--- a/src/services/tagging/climbing/gradeSystems.ts
+++ b/src/services/tagging/climbing/gradeSystems.ts
@@ -5,7 +5,7 @@ import { getClimbingAttributes } from './climbingAttributes';
 export const GRADE_SYSTEMS = [
   {
     key: 'uiaa', // TODO this should be `as const` otherwise it is just string
-    category: 'sport',
+    category: 'roped',
     name: 'UIAA',
     flags: '🇪🇺',
     minor: false,
@@ -14,7 +14,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'french',
-    category: 'sport',
+    category: 'roped',
     name: 'French',
     flags: '🇪🇺',
     minor: false,
@@ -23,7 +23,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'saxon',
-    category: 'sport',
+    category: 'roped',
     name: 'Saxon',
     flags: '🇩🇪🇨🇿',
     minor: false,
@@ -32,7 +32,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'yds_class',
-    category: 'sport',
+    category: 'roped',
     name: 'YDS',
     flags: '🇺🇸',
     minor: false,
@@ -50,7 +50,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'british_traditional',
-    category: 'sport',
+    category: 'roped',
     name: 'British technical',
     flags: '🇬🇧',
     minor: true,
@@ -58,7 +58,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'british_adjectival',
-    category: 'sport',
+    category: 'roped',
     name: 'British Adjectival',
     flags: '🇬🇧',
     minor: true,
@@ -67,7 +67,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'french_british',
-    category: 'sport',
+    category: 'roped',
     name: 'French British',
     flags: '🇬🇧🇮🇪',
     minor: true,
@@ -76,7 +76,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'norwegian',
-    category: 'sport',
+    category: 'roped',
     name: 'Norwegian',
     flags: '🇳🇴🇸🇪',
     minor: true,
@@ -100,7 +100,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'polish',
-    category: 'sport',
+    category: 'roped',
     name: 'Polish',
     flags: '🇵🇱',
     minor: true,
@@ -123,7 +123,7 @@ export const getGradeSystemName = (gradeSystemKey: GradeSystem) =>
 
 export const DEFAULT_GRADE_SYSTEM = 'uiaa';
 
-export type GradeSystemCategory = 'boulder' | 'sport' | 'ice' | 'mixed';
+export type GradeSystemCategory = 'boulder' | 'roped' | 'ice' | 'mixed';
 
 // Grouping follows the climbing style -> grading system table of id-tagging-schema
 export const GRADE_SYSTEM_CATEGORIES: {
@@ -132,8 +132,8 @@ export const GRADE_SYSTEM_CATEGORIES: {
   climbingTypes: string[];
 }[] = [
   {
-    key: 'sport',
-    label: 'climbing_badges.sport_label',
+    key: 'roped',
+    label: 'grade_system_select.category_roped',
     climbingTypes: ['sport', 'trad', 'deepwater'],
   },
   {

--- a/src/services/tagging/climbing/gradeSystems.ts
+++ b/src/services/tagging/climbing/gradeSystems.ts
@@ -5,7 +5,7 @@ import { getClimbingAttributes } from './climbingAttributes';
 export const GRADE_SYSTEMS = [
   {
     key: 'uiaa', // TODO this should be `as const` otherwise it is just string
-    category: 'roped',
+    category: 'routes',
     name: 'UIAA',
     flags: '🇪🇺',
     minor: false,
@@ -14,7 +14,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'french',
-    category: 'roped',
+    category: 'routes',
     name: 'French',
     flags: '🇪🇺',
     minor: false,
@@ -23,7 +23,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'saxon',
-    category: 'roped',
+    category: 'routes',
     name: 'Saxon',
     flags: '🇩🇪🇨🇿',
     minor: false,
@@ -32,7 +32,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'yds_class',
-    category: 'roped',
+    category: 'routes',
     name: 'YDS',
     flags: '🇺🇸',
     minor: false,
@@ -50,7 +50,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'british_traditional',
-    category: 'roped',
+    category: 'routes',
     name: 'British technical',
     flags: '🇬🇧',
     minor: true,
@@ -58,7 +58,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'british_adjectival',
-    category: 'roped',
+    category: 'routes',
     name: 'British Adjectival',
     flags: '🇬🇧',
     minor: true,
@@ -67,7 +67,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'french_british',
-    category: 'roped',
+    category: 'routes',
     name: 'French British',
     flags: '🇬🇧🇮🇪',
     minor: true,
@@ -76,7 +76,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'norwegian',
-    category: 'roped',
+    category: 'routes',
     name: 'Norwegian',
     flags: '🇳🇴🇸🇪',
     minor: true,
@@ -100,7 +100,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'polish',
-    category: 'roped',
+    category: 'routes',
     name: 'Polish',
     flags: '🇵🇱',
     minor: true,
@@ -123,7 +123,7 @@ export const getGradeSystemName = (gradeSystemKey: GradeSystem) =>
 
 export const DEFAULT_GRADE_SYSTEM = 'uiaa';
 
-export type GradeSystemCategory = 'boulder' | 'roped' | 'ice' | 'mixed';
+export type GradeSystemCategory = 'boulder' | 'routes' | 'ice' | 'mixed';
 
 // Grouping follows the climbing style -> grading system table of id-tagging-schema
 export const GRADE_SYSTEM_CATEGORIES: {
@@ -132,8 +132,8 @@ export const GRADE_SYSTEM_CATEGORIES: {
   climbingTypes: string[];
 }[] = [
   {
-    key: 'roped',
-    label: 'grade_system_select.category_roped',
+    key: 'routes',
+    label: 'grade_system_select.category_routes',
     climbingTypes: ['sport', 'trad', 'deepwater'],
   },
   {

--- a/src/services/tagging/climbing/gradeSystems.ts
+++ b/src/services/tagging/climbing/gradeSystems.ts
@@ -1,7 +1,11 @@
+import { FeatureTags, TranslationId } from '../../types';
+import { getClimbingAttributes } from './climbingAttributes';
+
 // The order of this array must be the same as CSV in gradeData.ts
 export const GRADE_SYSTEMS = [
   {
     key: 'uiaa', // TODO this should be `as const` otherwise it is just string
+    category: 'sport',
     name: 'UIAA',
     flags: '🇪🇺',
     minor: false,
@@ -10,6 +14,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'french',
+    category: 'sport',
     name: 'French',
     flags: '🇪🇺',
     minor: false,
@@ -18,6 +23,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'saxon',
+    category: 'sport',
     name: 'Saxon',
     flags: '🇩🇪🇨🇿',
     minor: false,
@@ -26,6 +32,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'yds_class',
+    category: 'sport',
     name: 'YDS',
     flags: '🇺🇸',
     minor: false,
@@ -34,6 +41,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'hueco',
+    category: 'boulder',
     name: 'V scale',
     flags: '🇺🇸',
     minor: false,
@@ -42,6 +50,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'british_traditional',
+    category: 'sport',
     name: 'British technical',
     flags: '🇬🇧',
     minor: true,
@@ -49,6 +58,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'british_adjectival',
+    category: 'sport',
     name: 'British Adjectival',
     flags: '🇬🇧',
     minor: true,
@@ -57,6 +67,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'french_british',
+    category: 'sport',
     name: 'French British',
     flags: '🇬🇧🇮🇪',
     minor: true,
@@ -65,6 +76,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'norwegian',
+    category: 'sport',
     name: 'Norwegian',
     flags: '🇳🇴🇸🇪',
     minor: true,
@@ -72,6 +84,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'ice',
+    category: 'ice',
     name: 'WI',
     flags: '🇨🇦',
     minor: true,
@@ -79,6 +92,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'mixed',
+    category: 'mixed',
     name: 'Mixed',
     minor: true,
     description:
@@ -86,6 +100,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'polish',
+    category: 'sport',
     name: 'Polish',
     flags: '🇵🇱',
     minor: true,
@@ -93,6 +108,7 @@ export const GRADE_SYSTEMS = [
   },
   {
     key: 'fb',
+    category: 'boulder',
     name: 'Fontainebleau',
     flags: '🇪🇺',
     minor: true,
@@ -106,3 +122,40 @@ export const getGradeSystemName = (gradeSystemKey: GradeSystem) =>
   GRADE_SYSTEMS.find((item) => item.key === gradeSystemKey)?.name;
 
 export const DEFAULT_GRADE_SYSTEM = 'uiaa';
+
+export type GradeSystemCategory = 'boulder' | 'sport' | 'ice' | 'mixed';
+
+// Grouping follows the climbing style -> grading system table of id-tagging-schema
+export const GRADE_SYSTEM_CATEGORIES: {
+  key: GradeSystemCategory;
+  label: TranslationId;
+  climbingTypes: string[];
+}[] = [
+  {
+    key: 'sport',
+    label: 'climbing_badges.sport_label',
+    climbingTypes: ['sport', 'trad', 'deepwater'],
+  },
+  {
+    key: 'boulder',
+    label: 'climbing_badges.boulder_label',
+    climbingTypes: ['boulder'],
+  },
+  { key: 'ice', label: 'climbing_badges.ice_label', climbingTypes: ['ice'] },
+  {
+    key: 'mixed',
+    label: 'climbing_badges.mixed_label',
+    climbingTypes: ['mixed'],
+  },
+];
+
+export const getGradeSystemCategoriesForTags = (tags: FeatureTags = {}) => {
+  const { climbingTypes } = getClimbingAttributes(tags);
+  const matches = (category: (typeof GRADE_SYSTEM_CATEGORIES)[number]) =>
+    category.climbingTypes.some((type) => climbingTypes.includes(type));
+
+  return [
+    ...GRADE_SYSTEM_CATEGORIES.filter(matches),
+    ...GRADE_SYSTEM_CATEGORIES.filter((category) => !matches(category)),
+  ];
+};

--- a/src/services/tagging/climbing/gradeSystems.ts
+++ b/src/services/tagging/climbing/gradeSystems.ts
@@ -149,10 +149,13 @@ export const GRADE_SYSTEM_CATEGORIES: {
   },
 ];
 
+// Only the feature's own tags - a climbing=crag does not inherit boulder-ness of its routes
 export const getGradeSystemCategoriesForTags = (tags: FeatureTags = {}) => {
   const { climbingTypes } = getClimbingAttributes(tags);
   const matches = (category: (typeof GRADE_SYSTEM_CATEGORIES)[number]) =>
-    category.climbingTypes.some((type) => climbingTypes.includes(type));
+    category.climbingTypes.some(
+      (type) => type === tags.climbing || climbingTypes.includes(type),
+    );
 
   return [
     ...GRADE_SYSTEM_CATEGORIES.filter(matches),


### PR DESCRIPTION
| sport climbing sector | climbing=boulder or climbing:boulder=* only |
|--|--|
| <img width="300" height="553" alt="image" src="https://github.com/user-attachments/assets/1af531bb-1d95-4ee1-ba06-2557d33ba1d5" /> | <img width="468" height="431" alt="image" src="https://github.com/user-attachments/assets/d00af143-8c70-47ba-967c-ce1b5170e839" />





Based on table by @elnappo:

| Climbing Style | Grading Systems |
|---|---|
| `climbing:boulder` | `climbing:grade:font`, `climbing:grade:hueco` |
| `climbing:sport`, `climbing:trad`, `climbing:deepwater` | `climbing:grade:french`, `climbing:grade:uiaa`, `climbing:grade:yds`, `climbing:grade:saxon`, `climbing:grade:norwegian`, `climbing:grade:ewbank`, `climbing:grade:polish`, `climbing:grade:british*` |
| `climbing:aid` | `climbing:grade:aid` |
| `climbing:ice` | `climbing:grade:ice` |
| `climbing:mixed` | `climbing:grade:mixed` |
| `climbing:dry` | `climbing:grade:dry` |